### PR TITLE
Add past years season long leaderboards 

### DIFF
--- a/app/components/layout/leaderboard/LeaderboardRow.tsx
+++ b/app/components/layout/leaderboard/LeaderboardRow.tsx
@@ -8,6 +8,8 @@ import type { Team } from "~/models/team.server";
 import type { TeamGame } from "~/models/teamgame.server";
 import type { User } from "~/models/user.server";
 
+import { RANK_COLORS, isLeagueName } from "~/utils/constants";
+
 // TODO: Clean up this typing.
 type Props = {
   position: TeamGame & {
@@ -27,15 +29,6 @@ export default function LeaderboardRow({ position, rank }: Props) {
     setShowDetails((prevState) => !prevState);
   };
 
-  // TODO: Export this from a single location, it gets used elsewhere.
-  const rankColors: Record<string, string> = {
-    admiral: "bg-admiral text-gray-900",
-    champions: "bg-champions text-gray-900",
-    dragon: "bg-dragon text-gray-900",
-    galaxy: "bg-galaxy text-gray-900",
-    monarch: "bg-monarch text-gray-900",
-  };
-
   const positionColors: Record<string, string> = {
     qb: "border-qb",
     rb: "border-rb",
@@ -44,6 +37,8 @@ export default function LeaderboardRow({ position, rank }: Props) {
     def: "border-def",
     empty: "border-gray-500",
   };
+
+  const leagueName = position.team.league.name.toLocaleLowerCase();
 
   return (
     <>
@@ -54,7 +49,7 @@ export default function LeaderboardRow({ position, rank }: Props) {
         <td className="pl-1">
           <div
             className={clsx(
-              rankColors[position.team.league.name.toLocaleLowerCase()],
+              isLeagueName(leagueName) && RANK_COLORS[leagueName],
               "mx-auto w-8 h-8 flex justify-center items-center font-bold text-sm"
             )}
           >

--- a/app/components/layout/standings/LeagueTable.tsx
+++ b/app/components/layout/standings/LeagueTable.tsx
@@ -2,18 +2,14 @@ import clsx from "clsx";
 
 import type { GetLeaguesByYearElement } from "~/models/league.server";
 
+import { RANK_COLORS, isLeagueName } from "~/utils/constants";
+
 type Props = {
   league: GetLeaguesByYearElement;
 };
 
 export default function LeagueTable({ league }: Props) {
-  const rankColors: Record<string, string> = {
-    admiral: "bg-admiral text-gray-900",
-    champions: "bg-champions text-gray-900",
-    dragon: "bg-dragon text-gray-900",
-    galaxy: "bg-galaxy text-gray-900",
-    monarch: "bg-monarch text-gray-900",
-  };
+  const leagueName = league.name.toLocaleLowerCase();
 
   return (
     <section>
@@ -37,7 +33,7 @@ export default function LeagueTable({ league }: Props) {
               <td>
                 <div
                   className={clsx(
-                    rankColors[league.name.toLocaleLowerCase()],
+                    isLeagueName(leagueName) && RANK_COLORS[leagueName],
                     "mx-auto w-8 h-8 flex justify-center items-center font-bold text-sm"
                   )}
                 >

--- a/app/routes/leagues.leaderboard.$year._index.tsx
+++ b/app/routes/leagues.leaderboard.$year._index.tsx
@@ -1,3 +1,80 @@
+import type { LoaderArgs } from "@remix-run/node";
+import clsx from "clsx";
+
+import { getTeamsInSeason } from "~/models/team.server";
+import { getTeamGameYearlyTotals } from "~/models/teamgame.server";
+
+import { RANK_COLORS, isLeagueName } from "~/utils/constants";
+import { superjson, useSuperLoaderData } from "~/utils/data";
+
+type LoaderData = {
+  leaderboard: Awaited<ReturnType<typeof getTeamGameYearlyTotals>>;
+  teams: Awaited<ReturnType<typeof getTeamsInSeason>>;
+  year: number;
+};
+
+export const loader = async ({ params }: LoaderArgs) => {
+  if (!params.year) {
+    throw new Error("No year param specified");
+  }
+
+  const year = Number(params.year);
+
+  const leaderboard = await getTeamGameYearlyTotals(year);
+  const teams = await getTeamsInSeason(year);
+
+  return superjson<LoaderData>(
+    { leaderboard, teams, year },
+    { headers: { "x-superjson": "true" } }
+  );
+};
+
 export default function LeaderboardYearIndex() {
-  return <div>Particular Year Leaderboard</div>;
+  const { leaderboard, teams, year } = useSuperLoaderData<typeof loader>();
+
+  return (
+    <>
+      <h2>{year} Season Leaderboard</h2>
+      <table>
+        <thead>
+          <tr>
+            <th></th>
+            <th>Player</th>
+            <th>Points For</th>
+          </tr>
+        </thead>
+        <tbody>
+          {leaderboard.map((position, index) => {
+            const team = teams.find((team) => team.id === position.teamId);
+            if (!team) return null;
+
+            const teamLeague = team.league.name.toLocaleLowerCase();
+
+            return (
+              <tr
+                key={position.teamId}
+                className={clsx(
+                  index % 2 === 0 ? "bg-gray-900" : "bg-gray-800",
+                  "p-2"
+                )}
+              >
+                <td className="pl-1">
+                  <div
+                    className={clsx(
+                      isLeagueName(teamLeague) && RANK_COLORS[teamLeague],
+                      "mx-auto w-8 h-8 flex justify-center items-center font-bold text-sm"
+                    )}
+                  >
+                    {index + 1}
+                  </div>
+                </td>
+                <td>{team.user?.discordName || "Missing user"}</td>
+                <td>{position._sum.pointsScored?.toFixed(2)}</td>
+              </tr>
+            );
+          })}
+        </tbody>
+      </table>
+    </>
+  );
 }

--- a/app/utils/constants.ts
+++ b/app/utils/constants.ts
@@ -3,3 +3,21 @@ export const SERVER_DISCORD_ID = `214093545747906562`;
 export const SERVER_DISCORD_ADMIN_ROLE_ID = `214097556051984385`;
 export const SERVER_DISCORD_PODCAST_ADMIN_ROLE_ID = `1006075042293108746`;
 export const SLEEPER_ADMIN_ID = `329096543967641600`;
+
+export enum Leagues {
+  admiral = "admiral",
+  champions = "champions",
+  dragon = "dragon",
+  galaxy = "galaxy",
+  monarch = "monarch",
+}
+export const isLeagueName = (value: string): value is Leagues =>
+  value in Leagues;
+
+export const RANK_COLORS: Record<Leagues, string> = {
+  admiral: "bg-admiral text-gray-900",
+  champions: "bg-champions text-gray-900",
+  dragon: "bg-dragon text-gray-900",
+  galaxy: "bg-galaxy text-gray-900",
+  monarch: "bg-monarch text-gray-900",
+};


### PR DESCRIPTION
This commit moves the rank colors record into a single file and adds an enum so that the typing is strong going forward.

This misses a single rank colors located in there but that refactor is slightly more complicated so we can get that at another time.