### PR TITLE
Add ability to store multiple sleeperIds on a user

### DIFF
--- a/app/models/sleeperUser.server.ts
+++ b/app/models/sleeperUser.server.ts
@@ -1,0 +1,35 @@
+import type { SleeperUser } from "@prisma/client";
+
+import { prisma } from "~/db.server";
+
+export type { SleeperUser } from "@prisma/client";
+
+export async function createOrUpdateSleeperUser(sleeperUser: SleeperUser) {
+  return prisma.sleeperUser.upsert({
+    where: {
+      sleeperOwnerID: sleeperUser.sleeperOwnerID,
+    },
+    update: {
+      userId: sleeperUser.userId,
+    },
+    create: sleeperUser,
+  });
+}
+
+export async function deleteSleeperUser(
+  sleeperOwnerID: SleeperUser["sleeperOwnerID"]
+) {
+  return prisma.sleeperUser.delete({
+    where: {
+      sleeperOwnerID: sleeperOwnerID,
+    },
+  });
+}
+
+export async function getSleeperOwnerIdsByUserId(id: SleeperUser["userId"]) {
+  return prisma.sleeperUser.findMany({
+    where: {
+      userId: id,
+    },
+  });
+}

--- a/app/models/user.server.ts
+++ b/app/models/user.server.ts
@@ -51,6 +51,9 @@ export async function getUsers() {
     orderBy: {
       discordName: "asc",
     },
+    include: {
+      sleeperUsers: true,
+    },
   });
 }
 
@@ -63,7 +66,6 @@ export async function updateUser(user: Partial<User>) {
       discordName: user.discordName || undefined,
       discordAvatar: user.discordAvatar || undefined,
       discordRoles: user.discordRoles || undefined,
-      sleeperOwnerID: user.sleeperOwnerID || undefined,
     },
   });
 }

--- a/app/routes/admin.leagues._index.tsx
+++ b/app/routes/admin.leagues._index.tsx
@@ -90,8 +90,12 @@ export const action = async ({ request }: ActionArgs) => {
       const existingTeamsSleeperOwners = (await getTeams(leagueId)).map(
         (team) => [team.sleeperOwnerId, team.id]
       );
-      const existingUsersSleeperIds = (await getUsers()).map(
-        ({ id, sleeperOwnerID }) => ({ id, sleeperOwnerID })
+      const existingUsersSleeperIds = (await getUsers()).flatMap(
+        ({ id, sleeperUsers }) =>
+          sleeperUsers.map((sleeperUser) => ({
+            id,
+            sleeperOwnerID: sleeperUser.sleeperOwnerID,
+          }))
       );
 
       if (sleeperDraft.start_time) {

--- a/app/routes/admin.members._index.tsx
+++ b/app/routes/admin.members._index.tsx
@@ -1,13 +1,16 @@
 import type { LoaderArgs } from "@remix-run/node";
 import { Link } from "@remix-run/react";
 
+import type { SleeperUser } from "~/models/sleeperUser.server";
 import type { User } from "~/models/user.server";
 import { getUsers } from "~/models/user.server";
 
 import { superjson, useSuperLoaderData } from "~/utils/data";
 
 type LoaderData = {
-  users: User[];
+  users: (User & {
+    sleeperUsers: SleeperUser[];
+  })[];
 };
 
 export const loader = async ({ request }: LoaderArgs) => {
@@ -29,7 +32,7 @@ export default function PodcastEpisodeList() {
         <thead>
           <tr>
             <th>Member</th>
-            <th>Sleeper ID</th>
+            <th>Sleeper IDs</th>
             <th>Actions</th>
           </tr>
         </thead>
@@ -37,7 +40,15 @@ export default function PodcastEpisodeList() {
           {users.map((user) => (
             <tr key={user.id}>
               <td>{user.discordName}</td>
-              <td>{user.sleeperOwnerID}</td>
+              <td>
+                <ul className="!my-0">
+                  {user.sleeperUsers.map((sleeperUser) => (
+                    <li key={sleeperUser.sleeperOwnerID} className="!my-1">
+                      {sleeperUser.sleeperOwnerID}
+                    </li>
+                  ))}
+                </ul>
+              </td>
               <td>
                 <Link to={`./${user.id}`}>Edit</Link>
               </td>

--- a/prisma/migrations/20240827041113_add_multiple_sleeper_accounts_to_user/migration.sql
+++ b/prisma/migrations/20240827041113_add_multiple_sleeper_accounts_to_user/migration.sql
@@ -1,0 +1,17 @@
+-- CreateTable
+CREATE TABLE "SleeperUser" (
+    "sleeperOwnerID" TEXT NOT NULL,
+    "userId" TEXT NOT NULL
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "SleeperUser_sleeperOwnerID_key" ON "SleeperUser"("sleeperOwnerID");
+
+-- AddForeignKey
+ALTER TABLE "SleeperUser" ADD CONSTRAINT "SleeperUser_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- CopyExistingData
+INSERT INTO "SleeperUser"("userId", "sleeperOwnerID") SELECT "id", "sleeperOwnerID" FROM "User" WHERE "sleeperOwnerID" != '';
+
+-- Remove Old Column
+ALTER TABLE "User" DROP COLUMN IF EXISTS "sleeperOwnerID";

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -396,6 +396,13 @@ model Season {
   registrationSize Int @default(60)
 }
 
+model SleeperUser {
+  sleeperOwnerID String @unique
+
+  user User @relation(fields: [userId], references: [id], onDelete: Cascade, onUpdate: Cascade)
+  userId String
+}
+
 model Team {
   id String @id @default(cuid())
   createdAt DateTime @default(now())
@@ -447,8 +454,6 @@ model User {
   discordAvatar String
   discordRoles String[]
 
-  sleeperOwnerID String @default("")
-
   registrations Registration[]
   episodes Episode[]
   teams Team[]
@@ -457,4 +462,5 @@ model User {
   QBSelections QBSelection[]
   poolWeeksMissed PoolWeekMissed[]
   locksGamePick LocksGamePick[]
+  sleeperUsers SleeperUser[]
 }


### PR DESCRIPTION
https://github.com/user-attachments/assets/18360993-3634-4cf6-9960-67f46db404d5

This change updates the model to separate out the sleeperOwnerId to its own table, which lets us have multiple owner IDs on a single user.

This is still a manual process to be done by the admins, but at least this lets us account for people with multiple sleeper accounts.

This change doesn't account for people having multiple discord accounts, we probably need a merge tool of some sort in the future but for now, it's so much of an edge case that it doesn't matter too much.

Closes #56