### PR TITLE
Add extra namespace for CSS variables

### DIFF
--- a/app/styles/variables.css
+++ b/app/styles/variables.css
@@ -1,4 +1,5 @@
-:root {
+/* Trying to solve a safari bug, in theory root should equal html */
+:root, html {
   --radius: 8px;
   --background: 215 25 27;
 }


### PR DESCRIPTION
This change adds html to the CSS namespace, which in theory resolves the bug where CSS variables within root are ignored by Safari when referencing a pseudo-selector.