### PR TITLE
Fix standings sorting

### DIFF
--- a/app/models/league.server.ts
+++ b/app/models/league.server.ts
@@ -71,6 +71,9 @@ export async function getLeaguesByYear(year: League['year']) {
             wins: 'desc',
           },
           {
+            ties: 'desc',
+          },
+          {
             pointsFor: 'desc',
           },
         ],


### PR DESCRIPTION
This fixes the sorting on ties. However, it's not really accurate, as really we should be sorting by win percentage. However, as long as we don't end up with multiple ties by the same team in a season, this will be correct so whatever.