### PR TITLE
Fixed issue where ADP sorting was off for undrafted players

### DIFF
--- a/app/routes/leagues.adp.$.tsx
+++ b/app/routes/leagues.adp.$.tsx
@@ -39,12 +39,12 @@ export const loader = async ({ params }: LoaderFunctionArgs) => {
       // position worst than the actual number of picks. There isn't a great way to solve this but
       // we've picked a way, I think.
       position._avg.pickNumber =
-        (position._avg.pickNumber! * position._count.pickNumber +
-          180 * (leagueCount - position._count.pickNumber)) /
+        ((position._avg.pickNumber! * position._count.pickNumber) +
+          (181 * (leagueCount - position._count.pickNumber))) /
         leagueCount;
     }
   }
-
+  adp.sort((a, b) => a._avg.pickNumber! - b._avg.pickNumber!);
   return typedjson({ adp, playersMap, year });
 };
 

--- a/app/routes/leagues.adp.$.tsx
+++ b/app/routes/leagues.adp.$.tsx
@@ -39,8 +39,8 @@ export const loader = async ({ params }: LoaderFunctionArgs) => {
       // position worst than the actual number of picks. There isn't a great way to solve this but
       // we've picked a way, I think.
       position._avg.pickNumber =
-        ((position._avg.pickNumber! * position._count.pickNumber) +
-          (181 * (leagueCount - position._count.pickNumber))) /
+        (position._avg.pickNumber! * position._count.pickNumber +
+          181 * (leagueCount - position._count.pickNumber)) /
         leagueCount;
     }
   }


### PR DESCRIPTION
Fixed adp sorting for undrafted players and made undrafted ADP equal 181 instead of 180.

Before: 
![image](https://github.com/user-attachments/assets/ebf52f78-c985-4f15-ac18-34df5012104e)

After:
![image](https://github.com/user-attachments/assets/0c5dd704-d56a-486b-a66f-fb6cd23f3c2d)
