### PR TITLE
Fixes spread pool reset issue

### DIFF
--- a/app/components/layout/spread-pool/SpreadPoolGame.tsx
+++ b/app/components/layout/spread-pool/SpreadPoolGame.tsx
@@ -36,7 +36,10 @@ export default function SpreadPoolGameComponent({
   const [betAmount, setBetAmount] = useState(
     Math.abs(existingBet?.amount || 0),
   );
-  const [showSlider, setShowSlider] = useState(false);
+  const [showSlider, setShowSlider] = useState(
+    Math.abs(existingBet?.amount || 0) > 0,
+  );
+  const [isBetReset, setIsBetReset] = useState(false);
 
   const betDisplay =
     betAmount !== 0 ? `${betAmount} on ${betTeam?.mascot}` : 'No Bet';
@@ -61,23 +64,19 @@ export default function SpreadPoolGameComponent({
 
   const onBetChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     if (+e.target.value > 0) {
+      setIsBetReset(false);
       setBetTeam(poolGame.game.homeTeam);
       setBetAmount(+e.target.value);
       handleChange([
-        { teamId: poolGame.game.homeTeam.id, amount: 0 },
+        { teamId: poolGame.game.homeTeam.id, amount: +e.target.value },
         { teamId: poolGame.game.awayTeam.id, amount: 0 },
       ]);
-      handleChange([
-        { teamId: poolGame.game.homeTeam.id, amount: +e.target.value },
-      ]);
     } else if (+e.target.value < 0) {
+      setIsBetReset(false);
       setBetTeam(poolGame.game.awayTeam);
       setBetAmount(-1 * +e.target.value);
       handleChange([
         { teamId: poolGame.game.homeTeam.id, amount: 0 },
-        { teamId: poolGame.game.awayTeam.id, amount: 0 },
-      ]);
-      handleChange([
         { teamId: poolGame.game.awayTeam.id, amount: -1 * +e.target.value },
       ]);
     } else {
@@ -95,7 +94,8 @@ export default function SpreadPoolGameComponent({
   };
 
   const resetBet = () => {
-    setBetTeam(null);
+    setBetTeam(existingBetTeam);
+    setIsBetReset(true);
     setBetAmount(0);
     handleChange([
       { teamId: poolGame.game.homeTeam.id, amount: 0 },
@@ -124,6 +124,13 @@ export default function SpreadPoolGameComponent({
           {formatSpread(poolGame.homeSpread, true)})
         </div>
       </div>
+      {isBetReset && (
+        <input
+          type='hidden'
+          name={`${poolGame.id}-${existingBetTeam?.id}`}
+          defaultValue={0}
+        />
+      )}
       {showSlider && (
         <>
           <input


### PR DESCRIPTION
This fixes an issue with the reset button not actually applying for a bet that was already entered. This is caused by a reset not making the component render. Easiest way to solve it was to keep track of if the reset button was hit recently and use a hidden input component with the team that was the previous bet so that it makes sure to zero it out.

This also does a minor optimization to not call handleChange twice. It also sets the default to show the slider if an existing bet is in the system, since we'd want that bet to be displayed anyhow.

https://github.com/user-attachments/assets/e25deaa1-a6ec-4aea-ae21-a12d839192a8