### PR TITLE
Fix late erase of spread pool bug.

### DIFF
--- a/app/routes/games.spread-pool.entries.$id.tsx
+++ b/app/routes/games.spread-pool.entries.$id.tsx
@@ -74,7 +74,7 @@ export const action = async ({ params, request }: ActionFunctionArgs) => {
     const [poolGameId, teamId] = key.split('-');
 
     const poolGame = poolGames.find(poolGame => poolGame.id === poolGameId);
-    if (!poolGame) continue;
+    if (!poolGame || poolGame.game.gameStartTime <= new Date()) continue;
 
     if (!teamId || teamId === 'undefined') {
       nflTeamIdToAmountBetMap.set(
@@ -88,21 +88,19 @@ export const action = async ({ params, request }: ActionFunctionArgs) => {
       continue;
     }
 
-    if (poolGame.game.gameStartTime > new Date()) {
-      nflTeamIdToAmountBetMap.set(key, Math.abs(+amount));
+    nflTeamIdToAmountBetMap.set(key, Math.abs(+amount));
 
-      // Get team that's the other side of this game and set to 0.
-      if (poolGame.game.awayTeamId === teamId) {
-        nflTeamIdToAmountBetMap.set(
-          `${poolGameId}-${poolGame.game.homeTeamId}`,
-          0,
-        );
-      } else {
-        nflTeamIdToAmountBetMap.set(
-          `${poolGameId}-${poolGame.game.awayTeamId}`,
-          0,
-        );
-      }
+    // Get team that's the other side of this game and set to 0.
+    if (poolGame.game.awayTeamId === teamId) {
+      nflTeamIdToAmountBetMap.set(
+        `${poolGameId}-${poolGame.game.homeTeamId}`,
+        0,
+      );
+    } else {
+      nflTeamIdToAmountBetMap.set(
+        `${poolGameId}-${poolGame.game.awayTeamId}`,
+        0,
+      );
     }
   }
 


### PR DESCRIPTION
This was a bug that addresses the following case in spread pool:

1. Player has a bet in place already
2. Player has page up for editing bets
3. Player sets bet to 0 after game starts
4. Player saves page

The issue is that for most things, it's checking the timestamp of the game in order to do things, so this usually doesn't matter, but we were dropping the game AFTER the check for no team, which isn't right. This fixes that.