### PR TITLE
Locks challenge default standings week changed

### DIFF
--- a/app/routes/games.tsx
+++ b/app/routes/games.tsx
@@ -28,7 +28,7 @@ export const loader = async ({ params, request }: LoaderFunctionArgs) => {
   let locksChallengeWeek = (await getLocksWeeksByYear(currentSeason.year))[0];
 
   const locksChallengeCurrentWeek =
-    locksChallengeWeek?.isWeekScored && locksChallengeWeek?.weekNumber === 0
+    locksChallengeWeek?.isWeekScored
       ? locksChallengeWeek?.weekNumber
       : locksChallengeWeek?.weekNumber - 1
       ? locksChallengeWeek?.weekNumber - 1

--- a/app/routes/games.tsx
+++ b/app/routes/games.tsx
@@ -30,9 +30,8 @@ export const loader = async ({ params, request }: LoaderFunctionArgs) => {
   const locksChallengeCurrentWeek =
     locksChallengeWeek?.isWeekScored
       ? locksChallengeWeek?.weekNumber
-      : locksChallengeWeek?.weekNumber - 1
-      ? locksChallengeWeek?.weekNumber - 1
-      : 1;
+      : locksChallengeWeek?.weekNumber - 1 
+      || 1;
 
   return typedjson(
     {

--- a/app/routes/games.tsx
+++ b/app/routes/games.tsx
@@ -27,11 +27,9 @@ export const loader = async ({ params, request }: LoaderFunctionArgs) => {
 
   let locksChallengeWeek = (await getLocksWeeksByYear(currentSeason.year))[0];
 
-  const locksChallengeCurrentWeek =
-    locksChallengeWeek?.isWeekScored
-      ? locksChallengeWeek?.weekNumber
-      : locksChallengeWeek?.weekNumber - 1 
-      || 1;
+  const locksChallengeCurrentWeek = locksChallengeWeek?.isWeekScored
+    ? locksChallengeWeek?.weekNumber
+    : locksChallengeWeek?.weekNumber - 1 || 1;
 
   return typedjson(
     {

--- a/app/routes/games.tsx
+++ b/app/routes/games.tsx
@@ -25,9 +25,11 @@ export const loader = async ({ params, request }: LoaderFunctionArgs) => {
     await getPoolWeeksByYear(currentSeason.year)
   )[0]?.weekNumber;
 
-  const locksChallengeCurrentWeek = (
+  let locksChallengeWeek = (
     await getLocksWeeksByYear(currentSeason.year)
-  )[0]?.weekNumber;
+  )[0];
+  
+  const locksChallengeCurrentWeek = (locksChallengeWeek?.isWeekScored && (locksChallengeWeek?.weekNumber === 0)) ? locksChallengeWeek?.weekNumber : (locksChallengeWeek?.weekNumber - 1 ? locksChallengeWeek?.weekNumber - 1 : 1);
 
   return typedjson(
     {

--- a/app/routes/games.tsx
+++ b/app/routes/games.tsx
@@ -25,11 +25,14 @@ export const loader = async ({ params, request }: LoaderFunctionArgs) => {
     await getPoolWeeksByYear(currentSeason.year)
   )[0]?.weekNumber;
 
-  let locksChallengeWeek = (
-    await getLocksWeeksByYear(currentSeason.year)
-  )[0];
-  
-  const locksChallengeCurrentWeek = (locksChallengeWeek?.isWeekScored && (locksChallengeWeek?.weekNumber === 0)) ? locksChallengeWeek?.weekNumber : (locksChallengeWeek?.weekNumber - 1 ? locksChallengeWeek?.weekNumber - 1 : 1);
+  let locksChallengeWeek = (await getLocksWeeksByYear(currentSeason.year))[0];
+
+  const locksChallengeCurrentWeek =
+    locksChallengeWeek?.isWeekScored && locksChallengeWeek?.weekNumber === 0
+      ? locksChallengeWeek?.weekNumber
+      : locksChallengeWeek?.weekNumber - 1
+      ? locksChallengeWeek?.weekNumber - 1
+      : 1;
 
   return typedjson(
     {


### PR DESCRIPTION
Default week change to last scored week. If no week has been scored then show week 1

Unnecessary change but was annoying me