### PR TITLE
feat: implement Record Books leaderboard page

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,4 @@ tsconfig.tsbuildinfo
 /playwright/.cache/
 
 tsconfig.tsbuildinfo
+.grepai/

--- a/.mcp.json
+++ b/.mcp.json
@@ -2,10 +2,7 @@
   "mcpServers": {
     "shadcn": {
       "command": "npx",
-      "args": [
-        "shadcn@latest",
-        "mcp"
-      ]
+      "args": ["shadcn@latest", "mcp"]
     }
   }
 }

--- a/app/components/layout/records/RecordsTable.tsx
+++ b/app/components/layout/records/RecordsTable.tsx
@@ -25,9 +25,7 @@ export default function RecordsTable({ title, headers, rows }: Props) {
           {rows.map((row, index) => (
             <tr
               key={index}
-              className={clsx(
-                index % 2 === 0 ? 'bg-gray-900' : 'bg-gray-800',
-              )}
+              className={clsx(index % 2 === 0 ? 'bg-gray-900' : 'bg-gray-800')}
             >
               <td className='px-2'>
                 <div

--- a/app/components/layout/records/RecordsTable.tsx
+++ b/app/components/layout/records/RecordsTable.tsx
@@ -1,0 +1,53 @@
+import clsx from 'clsx';
+import type { RecordRow } from '~/models/records.server';
+import { isLeagueName, RANK_COLORS } from '~/utils/constants';
+
+type Props = {
+  title: string;
+  headers: string[];
+  rows: RecordRow[];
+};
+
+export default function RecordsTable({ title, headers, rows }: Props) {
+  return (
+    <section className='mb-8'>
+      <h3>{title}</h3>
+      <table>
+        <thead>
+          <tr>
+            <th></th>
+            {headers.map((header, i) => (
+              <th key={i}>{header}</th>
+            ))}
+          </tr>
+        </thead>
+        <tbody>
+          {rows.map((row, index) => (
+            <tr
+              key={index}
+              className={clsx(
+                index % 2 === 0 ? 'bg-gray-900' : 'bg-gray-800',
+              )}
+            >
+              <td className='px-2'>
+                <div
+                  className={clsx(
+                    isLeagueName(row.leagueName ?? '')
+                      ? RANK_COLORS[row.leagueName as keyof typeof RANK_COLORS]
+                      : 'bg-gray-700 text-gray-200',
+                    'mx-auto w-8 h-8 flex justify-center items-center font-bold text-sm',
+                  )}
+                >
+                  {index + 1}
+                </div>
+              </td>
+              {row.cells.map((cell, i) => (
+                <td key={i}>{cell}</td>
+              ))}
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </section>
+  );
+}

--- a/app/components/ui/popover.tsx
+++ b/app/components/ui/popover.tsx
@@ -1,31 +1,30 @@
-import * as React from "react"
-import * as PopoverPrimitive from "@radix-ui/react-popover"
+import * as PopoverPrimitive from '@radix-ui/react-popover';
+import * as React from 'react';
+import { cn } from '~/utils';
 
-import { cn } from "~/utils"
+const Popover = PopoverPrimitive.Root;
 
-const Popover = PopoverPrimitive.Root
+const PopoverTrigger = PopoverPrimitive.Trigger;
 
-const PopoverTrigger = PopoverPrimitive.Trigger
-
-const PopoverAnchor = PopoverPrimitive.Anchor
+const PopoverAnchor = PopoverPrimitive.Anchor;
 
 const PopoverContent = React.forwardRef<
   React.ElementRef<typeof PopoverPrimitive.Content>,
   React.ComponentPropsWithoutRef<typeof PopoverPrimitive.Content>
->(({ className, align = "center", sideOffset = 4, ...props }, ref) => (
+>(({ className, align = 'center', sideOffset = 4, ...props }, ref) => (
   <PopoverPrimitive.Portal>
     <PopoverPrimitive.Content
       ref={ref}
       align={align}
       sideOffset={sideOffset}
       className={cn(
-        "z-50 w-72 rounded-md border bg-popover p-4 text-popover-foreground shadow-md outline-none data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 origin-[--radix-popover-content-transform-origin]",
-        className
+        'z-50 w-72 rounded-md border bg-popover p-4 text-popover-foreground shadow-md outline-none data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 origin-[--radix-popover-content-transform-origin]',
+        className,
       )}
       {...props}
     />
   </PopoverPrimitive.Portal>
-))
-PopoverContent.displayName = PopoverPrimitive.Content.displayName
+));
+PopoverContent.displayName = PopoverPrimitive.Content.displayName;
 
-export { Popover, PopoverTrigger, PopoverContent, PopoverAnchor }
+export { Popover, PopoverTrigger, PopoverContent, PopoverAnchor };

--- a/app/libs/league-sync.server.ts
+++ b/app/libs/league-sync.server.ts
@@ -1,11 +1,16 @@
+import { syncAdp } from './syncs.server';
 import { DateTime } from 'luxon';
 import { env } from 'process';
-import { syncAdp } from './syncs.server';
 import { updateLeague, type League } from '~/models/league.server';
 import { createTeam, getTeams, updateTeam } from '~/models/team.server';
 import { getUsers } from '~/models/user.server';
 import { SLEEPER_ADMIN_ID } from '~/utils/constants';
-import { sleeperTeamJson, sleeperDraftJson, type SleeperTeamJson, type SleeperDraftJson } from '~/utils/types';
+import {
+  sleeperTeamJson,
+  sleeperDraftJson,
+  type SleeperTeamJson,
+  type SleeperDraftJson,
+} from '~/utils/types';
 
 /**
  * Syncs a single league with Sleeper API data
@@ -16,7 +21,7 @@ export async function syncLeague(league: League): Promise<void> {
   // Fetch data from Sleeper API
   const teamsUrl = `https://api.sleeper.app/v1/league/${league.sleeperLeagueId}/rosters`;
   const draftsUrl = `https://api.sleeper.app/v1/draft/${league.sleeperDraftId}`;
-  
+
   const [sleeperTeamsRes, sleeperDraftRes] = await Promise.all([
     fetch(teamsUrl),
     fetch(draftsUrl),
@@ -43,9 +48,10 @@ export async function syncLeague(league: League): Promise<void> {
   );
 
   // Get existing teams for this league
-  const existingTeamsSleeperOwners = (await getTeams(league.id)).map(
-    team => [team.sleeperOwnerId, team.id],
-  );
+  const existingTeamsSleeperOwners = (await getTeams(league.id)).map(team => [
+    team.sleeperOwnerId,
+    team.id,
+  ]);
 
   // Get users once for this sync operation
   const existingUsersSleeperIds = (await getUsers()).flatMap(
@@ -168,7 +174,8 @@ export async function syncMultipleLeagues(leagues: League[]): Promise<{
       console.log(`✅ Successfully synced league: ${league.name}`);
     } catch (error) {
       errorCount++;
-      const errorMessage = error instanceof Error ? error.message : 'Unknown error';
+      const errorMessage =
+        error instanceof Error ? error.message : 'Unknown error';
       errors.push({ leagueName: league.name, error: errorMessage });
       console.error(`❌ Failed to sync league ${league.name}:`, error);
     }

--- a/app/models/draftSlot.server.ts
+++ b/app/models/draftSlot.server.ts
@@ -5,10 +5,7 @@ export type { DraftSlot } from '@prisma/client';
 
 export function getDraftSlots() {
   return prisma.draftSlot.findMany({
-    orderBy: [
-      { season: 'desc' },
-      { draftDateTime: 'asc' },
-    ],
+    orderBy: [{ season: 'desc' }, { draftDateTime: 'asc' }],
   });
 }
 
@@ -26,10 +23,7 @@ export async function getDraftSlotsWithPreferenceCounts() {
         },
       },
     },
-    orderBy: [
-      { season: 'desc' },
-      { draftDateTime: 'asc' },
-    ],
+    orderBy: [{ season: 'desc' }, { draftDateTime: 'asc' }],
   });
 
   return draftSlots.map(slot => ({
@@ -46,7 +40,7 @@ export async function getUniqueUsersWithPreferences() {
     },
     distinct: ['userId'],
   });
-  
+
   return uniqueUsers.length;
 }
 

--- a/app/models/draftSlotPreference.server.ts
+++ b/app/models/draftSlotPreference.server.ts
@@ -13,7 +13,7 @@ export type DraftSlotPreferenceWithDraftSlot = DraftSlotPreference & {
 
 export async function getUserDraftSlotPreferences(
   userId: string,
-  season: number
+  season: number,
 ): Promise<DraftSlotPreferenceWithDraftSlot[]> {
   return prisma.draftSlotPreference.findMany({
     where: {
@@ -38,7 +38,7 @@ export async function getUserDraftSlotPreferences(
 export async function upsertUserDraftSlotPreferences(
   userId: string,
   season: number,
-  preferences: { draftSlotId: string; ranking: number }[]
+  preferences: { draftSlotId: string; ranking: number }[],
 ): Promise<void> {
   // Delete existing preferences for this user and season
   await prisma.draftSlotPreference.deleteMany({
@@ -51,7 +51,7 @@ export async function upsertUserDraftSlotPreferences(
   // Create new preferences
   if (preferences.length > 0) {
     await prisma.draftSlotPreference.createMany({
-      data: preferences.map((pref) => ({
+      data: preferences.map(pref => ({
         userId,
         draftSlotId: pref.draftSlotId,
         season,
@@ -63,7 +63,7 @@ export async function upsertUserDraftSlotPreferences(
 
 export async function getDraftSlotsWithUserPreferences(
   userId: string,
-  season: number
+  season: number,
 ) {
   const draftSlots = await prisma.draftSlot.findMany({
     where: {
@@ -84,7 +84,7 @@ export async function getDraftSlotsWithUserPreferences(
     },
   });
 
-  return draftSlots.map((slot) => ({
+  return draftSlots.map(slot => ({
     ...slot,
     userRanking: slot.preferences[0]?.ranking || null,
   }));

--- a/app/models/records.server.ts
+++ b/app/models/records.server.ts
@@ -1,0 +1,691 @@
+import { prisma } from '~/db.server';
+
+const TOP_N = 50;
+const MIN_SEASONS = 2;
+
+export type RecordRow = {
+  cells: string[];
+  leagueName?: string;
+};
+
+export type RecordTable = {
+  title: string;
+  headers: string[];
+  rows: RecordRow[];
+};
+
+export async function getCareerRecords(): Promise<RecordTable[]> {
+  const teams = await prisma.team.findMany({
+    where: { userId: { not: null } },
+    include: {
+      user: { select: { discordName: true, id: true } },
+    },
+  });
+
+  interface CareerStats {
+    name: string;
+    seasons: number;
+    wins: number;
+    losses: number;
+    ties: number;
+    pointsFor: number;
+    pointsAgainst: number;
+    medianWins: number;
+    medianLosses: number;
+    medianTies: number;
+  }
+
+  const map = new Map<string, CareerStats>();
+
+  for (const team of teams) {
+    if (!team.userId) continue;
+    const existing = map.get(team.userId) || {
+      name: team.user?.discordName || 'Unknown',
+      seasons: 0,
+      wins: 0,
+      losses: 0,
+      ties: 0,
+      pointsFor: 0,
+      pointsAgainst: 0,
+      medianWins: 0,
+      medianLosses: 0,
+      medianTies: 0,
+    };
+    existing.seasons++;
+    existing.wins += team.wins;
+    existing.losses += team.losses;
+    existing.ties += team.ties;
+    existing.pointsFor += team.pointsFor;
+    existing.pointsAgainst += team.pointsAgainst;
+    existing.medianWins += team.medianWins;
+    existing.medianLosses += team.medianLosses;
+    existing.medianTies += team.medianTies;
+    map.set(team.userId, existing);
+  }
+
+  const careers = Array.from(map.values());
+
+  const totalGames = (c: CareerStats) => c.wins + c.losses + c.ties;
+  const winPct = (c: CareerStats) =>
+    totalGames(c) > 0 ? c.wins / totalGames(c) : 0;
+  const avgPF = (c: CareerStats) =>
+    c.seasons > 0 ? c.pointsFor / c.seasons : 0;
+
+  return [
+    {
+      title: 'Most Career Wins',
+      headers: ['Player', 'Wins', 'Record', 'Seasons'],
+      rows: [...careers]
+        .sort((a, b) => b.wins - a.wins)
+        .slice(0, TOP_N)
+        .map(c => ({
+          cells: [
+            c.name,
+            c.wins.toString(),
+            `${c.wins}-${c.losses}-${c.ties}`,
+            c.seasons.toString(),
+          ],
+        })),
+    },
+    {
+      title: 'Most Career Losses',
+      headers: ['Player', 'Losses', 'Record', 'Seasons'],
+      rows: [...careers]
+        .sort((a, b) => b.losses - a.losses)
+        .slice(0, TOP_N)
+        .map(c => ({
+          cells: [
+            c.name,
+            c.losses.toString(),
+            `${c.wins}-${c.losses}-${c.ties}`,
+            c.seasons.toString(),
+          ],
+        })),
+    },
+    {
+      title: 'Highest Career Win Percentage',
+      headers: ['Player', 'Win %', 'Record', 'Seasons'],
+      rows: [...careers]
+        .filter(c => c.seasons >= MIN_SEASONS)
+        .sort((a, b) => winPct(b) - winPct(a))
+        .slice(0, TOP_N)
+        .map(c => ({
+          cells: [
+            c.name,
+            (winPct(c) * 100).toFixed(1) + '%',
+            `${c.wins}-${c.losses}-${c.ties}`,
+            c.seasons.toString(),
+          ],
+        })),
+    },
+    {
+      title: 'Most Career Points For',
+      headers: ['Player', 'Points For', 'Avg/Season', 'Seasons'],
+      rows: [...careers]
+        .sort((a, b) => b.pointsFor - a.pointsFor)
+        .slice(0, TOP_N)
+        .map(c => ({
+          cells: [
+            c.name,
+            c.pointsFor.toFixed(2),
+            avgPF(c).toFixed(2),
+            c.seasons.toString(),
+          ],
+        })),
+    },
+    {
+      title: 'Most Career Points Against',
+      headers: ['Player', 'Points Against', 'Seasons'],
+      rows: [...careers]
+        .sort((a, b) => b.pointsAgainst - a.pointsAgainst)
+        .slice(0, TOP_N)
+        .map(c => ({
+          cells: [
+            c.name,
+            c.pointsAgainst.toFixed(2),
+            c.seasons.toString(),
+          ],
+        })),
+    },
+    {
+      title: 'Highest Average Points For per Season',
+      headers: ['Player', 'Avg PF/Season', 'Total PF', 'Seasons'],
+      rows: [...careers]
+        .filter(c => c.seasons >= MIN_SEASONS)
+        .sort((a, b) => avgPF(b) - avgPF(a))
+        .slice(0, TOP_N)
+        .map(c => ({
+          cells: [
+            c.name,
+            avgPF(c).toFixed(2),
+            c.pointsFor.toFixed(2),
+            c.seasons.toString(),
+          ],
+        })),
+    },
+    {
+      title: 'Most Career Median Wins',
+      headers: ['Player', 'Median Wins', 'Median Record', 'Seasons'],
+      rows: [...careers]
+        .sort((a, b) => b.medianWins - a.medianWins)
+        .slice(0, TOP_N)
+        .map(c => ({
+          cells: [
+            c.name,
+            c.medianWins.toString(),
+            `${c.medianWins}-${c.medianLosses}-${c.medianTies}`,
+            c.seasons.toString(),
+          ],
+        })),
+    },
+    {
+      title: 'Most Seasons Played',
+      headers: ['Player', 'Seasons', 'Career Record'],
+      rows: [...careers]
+        .sort((a, b) => b.seasons - a.seasons || b.wins - a.wins)
+        .slice(0, TOP_N)
+        .map(c => ({
+          cells: [
+            c.name,
+            c.seasons.toString(),
+            `${c.wins}-${c.losses}-${c.ties}`,
+          ],
+        })),
+    },
+  ];
+}
+
+export async function getSingleSeasonRecords(): Promise<RecordTable[]> {
+  const teams = await prisma.team.findMany({
+    where: { userId: { not: null } },
+    include: {
+      user: { select: { discordName: true } },
+      league: { select: { year: true, name: true } },
+    },
+  });
+
+  const totalGames = (t: (typeof teams)[number]) =>
+    t.wins + t.losses + t.ties;
+  const winPct = (t: (typeof teams)[number]) =>
+    totalGames(t) > 0 ? t.wins / totalGames(t) : 0;
+  const differential = (t: (typeof teams)[number]) =>
+    t.pointsFor - t.pointsAgainst;
+
+  const makeRow = (
+    t: (typeof teams)[number],
+    value: string,
+  ): RecordRow => ({
+    cells: [
+      t.user?.discordName || 'Unknown',
+      value,
+      t.league.year.toString(),
+      t.league.name,
+    ],
+    leagueName: t.league.name.toLowerCase(),
+  });
+
+  return [
+    {
+      title: 'Most Wins in a Season',
+      headers: ['Player', 'Record', 'Year', 'League'],
+      rows: [...teams]
+        .sort((a, b) => b.wins - a.wins || b.pointsFor - a.pointsFor)
+        .slice(0, TOP_N)
+        .map(t => makeRow(t, `${t.wins}-${t.losses}-${t.ties}`)),
+    },
+    {
+      title: 'Best Win Percentage',
+      headers: ['Player', 'Win %', 'Year', 'League'],
+      rows: [...teams]
+        .filter(t => totalGames(t) > 0)
+        .sort((a, b) => winPct(b) - winPct(a))
+        .slice(0, TOP_N)
+        .map(t => makeRow(t, (winPct(t) * 100).toFixed(1) + '%')),
+    },
+    {
+      title: 'Most Points For in a Season',
+      headers: ['Player', 'Points For', 'Year', 'League'],
+      rows: [...teams]
+        .sort((a, b) => b.pointsFor - a.pointsFor)
+        .slice(0, TOP_N)
+        .map(t => makeRow(t, t.pointsFor.toFixed(2))),
+    },
+    {
+      title: 'Most Points Against in a Season',
+      headers: ['Player', 'Points Against', 'Year', 'League'],
+      rows: [...teams]
+        .sort((a, b) => b.pointsAgainst - a.pointsAgainst)
+        .slice(0, TOP_N)
+        .map(t => makeRow(t, t.pointsAgainst.toFixed(2))),
+    },
+    {
+      title: 'Largest Points Differential (PF - PA)',
+      headers: ['Player', 'Differential', 'Year', 'League'],
+      rows: [...teams]
+        .sort((a, b) => differential(b) - differential(a))
+        .slice(0, TOP_N)
+        .map(t =>
+          makeRow(
+            t,
+            differential(t) > 0
+              ? `+${differential(t).toFixed(2)}`
+              : differential(t).toFixed(2),
+          ),
+        ),
+    },
+    {
+      title: 'Most Median Wins in a Season',
+      headers: ['Player', 'Median Record', 'Year', 'League'],
+      rows: [...teams]
+        .sort((a, b) => b.medianWins - a.medianWins)
+        .slice(0, TOP_N)
+        .map(t =>
+          makeRow(t, `${t.medianWins}-${t.medianLosses}-${t.medianTies}`),
+        ),
+    },
+  ];
+}
+
+export async function getSingleGameRecords(): Promise<RecordTable[]> {
+  const [highestGames, lowestGames] = await Promise.all([
+    prisma.teamGame.findMany({
+      where: {
+        isRegularSeason: true,
+        team: { userId: { not: null } },
+      },
+      include: {
+        team: {
+          include: {
+            user: { select: { discordName: true } },
+            league: { select: { year: true, name: true } },
+          },
+        },
+      },
+      orderBy: { pointsScored: 'desc' },
+      take: TOP_N,
+    }),
+    prisma.teamGame.findMany({
+      where: {
+        isRegularSeason: true,
+        pointsScored: { gt: 0 },
+        team: { userId: { not: null } },
+      },
+      include: {
+        team: {
+          include: {
+            user: { select: { discordName: true } },
+            league: { select: { year: true, name: true } },
+          },
+        },
+      },
+      orderBy: { pointsScored: 'asc' },
+      take: TOP_N,
+    }),
+  ]);
+
+  const makeRow = (
+    g:
+      | (typeof highestGames)[number]
+      | (typeof lowestGames)[number],
+  ): RecordRow => ({
+    cells: [
+      g.team.user?.discordName || 'Unknown',
+      g.pointsScored.toFixed(2),
+      `W${g.week}`,
+      g.team.league.year.toString(),
+      g.team.league.name,
+    ],
+    leagueName: g.team.league.name.toLowerCase(),
+  });
+
+  return [
+    {
+      title: 'Highest Score in a Single Week',
+      headers: ['Player', 'Points', 'Week', 'Year', 'League'],
+      rows: highestGames.map(makeRow),
+    },
+    {
+      title: 'Lowest Score in a Single Week',
+      headers: ['Player', 'Points', 'Week', 'Year', 'League'],
+      rows: lowestGames.map(makeRow),
+    },
+  ];
+}
+
+export async function getCupRecords(): Promise<RecordTable[]> {
+  const cupGames = await prisma.cupGame.findMany({
+    where: {
+      winningTeamId: { not: null },
+    },
+    include: {
+      winningTeam: {
+        include: {
+          team: {
+            include: {
+              user: { select: { discordName: true, id: true } },
+            },
+          },
+        },
+      },
+      topTeam: {
+        include: {
+          team: {
+            include: {
+              user: { select: { discordName: true, id: true } },
+            },
+          },
+        },
+      },
+      bottomTeam: {
+        include: {
+          team: {
+            include: {
+              user: { select: { discordName: true, id: true } },
+            },
+          },
+        },
+      },
+    },
+  });
+
+  interface CupStats {
+    name: string;
+    championships: number;
+    finalsAppearances: number;
+    gameWins: number;
+    gamesPlayed: number;
+  }
+
+  const cupStatsMap = new Map<string, CupStats>();
+
+  const getOrCreate = (userId: string, name: string): CupStats => {
+    if (!cupStatsMap.has(userId)) {
+      cupStatsMap.set(userId, {
+        name,
+        championships: 0,
+        finalsAppearances: 0,
+        gameWins: 0,
+        gamesPlayed: 0,
+      });
+    }
+    return cupStatsMap.get(userId)!;
+  };
+
+  for (const game of cupGames) {
+    if (game.topTeam?.team.userId) {
+      const stats = getOrCreate(
+        game.topTeam.team.userId,
+        game.topTeam.team.user?.discordName || 'Unknown',
+      );
+      stats.gamesPlayed++;
+    }
+    if (game.bottomTeam?.team.userId) {
+      const stats = getOrCreate(
+        game.bottomTeam.team.userId,
+        game.bottomTeam.team.user?.discordName || 'Unknown',
+      );
+      stats.gamesPlayed++;
+    }
+    if (game.winningTeam?.team.userId) {
+      const stats = getOrCreate(
+        game.winningTeam.team.userId,
+        game.winningTeam.team.user?.discordName || 'Unknown',
+      );
+      stats.gameWins++;
+    }
+    if (game.round === 'ROUND_OF_2') {
+      if (game.topTeam?.team.userId) {
+        getOrCreate(
+          game.topTeam.team.userId,
+          game.topTeam.team.user?.discordName || 'Unknown',
+        ).finalsAppearances++;
+      }
+      if (game.bottomTeam?.team.userId) {
+        getOrCreate(
+          game.bottomTeam.team.userId,
+          game.bottomTeam.team.user?.discordName || 'Unknown',
+        ).finalsAppearances++;
+      }
+      if (game.winningTeam?.team.userId) {
+        getOrCreate(
+          game.winningTeam.team.userId,
+          game.winningTeam.team.user?.discordName || 'Unknown',
+        ).championships++;
+      }
+    }
+  }
+
+  const cupStats = Array.from(cupStatsMap.values());
+
+  return [
+    {
+      title: 'Most Cup Championships',
+      headers: ['Player', 'Championships', 'Finals', 'Games Won'],
+      rows: [...cupStats]
+        .sort(
+          (a, b) =>
+            b.championships - a.championships ||
+            b.finalsAppearances - a.finalsAppearances,
+        )
+        .filter(c => c.championships > 0)
+        .slice(0, TOP_N)
+        .map(c => ({
+          cells: [
+            c.name,
+            c.championships.toString(),
+            c.finalsAppearances.toString(),
+            c.gameWins.toString(),
+          ],
+        })),
+    },
+    {
+      title: 'Most Cup Finals Appearances',
+      headers: ['Player', 'Finals', 'Championships', 'Games Won'],
+      rows: [...cupStats]
+        .filter(c => c.finalsAppearances > 0)
+        .sort(
+          (a, b) =>
+            b.finalsAppearances - a.finalsAppearances ||
+            b.championships - a.championships,
+        )
+        .slice(0, TOP_N)
+        .map(c => ({
+          cells: [
+            c.name,
+            c.finalsAppearances.toString(),
+            c.championships.toString(),
+            c.gameWins.toString(),
+          ],
+        })),
+    },
+    {
+      title: 'Most Cup Game Wins',
+      headers: ['Player', 'Wins', 'Games Played', 'Win %'],
+      rows: [...cupStats]
+        .sort((a, b) => b.gameWins - a.gameWins)
+        .slice(0, TOP_N)
+        .map(c => ({
+          cells: [
+            c.name,
+            c.gameWins.toString(),
+            c.gamesPlayed.toString(),
+            c.gamesPlayed > 0
+              ? ((c.gameWins / c.gamesPlayed) * 100).toFixed(1) + '%'
+              : '0%',
+          ],
+        })),
+    },
+  ];
+}
+
+export async function getStreakRecords(): Promise<RecordTable[]> {
+  const allGames = await prisma.teamGame.findMany({
+    where: {
+      isRegularSeason: true,
+      pointsScored: { gt: 0 },
+      team: { userId: { not: null } },
+    },
+    include: {
+      team: {
+        include: {
+          user: { select: { discordName: true, id: true } },
+          league: { select: { year: true, name: true, id: true } },
+        },
+      },
+    },
+  });
+
+  const matchupMap = new Map<string, (typeof allGames)[number][]>();
+  for (const game of allGames) {
+    const key = `${game.team.leagueId}:${game.week}:${game.sleeperMatchupId}`;
+    if (!matchupMap.has(key)) matchupMap.set(key, []);
+    matchupMap.get(key)!.push(game);
+  }
+
+  interface GameResult {
+    teamId: string;
+    userName: string;
+    year: number;
+    week: number;
+    pointsScored: number;
+    leagueName: string;
+    result: 'W' | 'L' | 'T';
+  }
+
+  const gameResults: GameResult[] = [];
+  for (const [, games] of matchupMap) {
+    if (games.length !== 2) continue;
+    const [g1, g2] = games;
+
+    const r1: 'W' | 'L' | 'T' =
+      g1.pointsScored > g2.pointsScored
+        ? 'W'
+        : g1.pointsScored < g2.pointsScored
+          ? 'L'
+          : 'T';
+    const r2: 'W' | 'L' | 'T' =
+      r1 === 'W' ? 'L' : r1 === 'L' ? 'W' : 'T';
+
+    gameResults.push({
+      teamId: g1.teamId,
+      userName: g1.team.user?.discordName || 'Unknown',
+      year: g1.team.league.year,
+      week: g1.week,
+      pointsScored: g1.pointsScored,
+      leagueName: g1.team.league.name,
+      result: r1,
+    });
+
+    gameResults.push({
+      teamId: g2.teamId,
+      userName: g2.team.user?.discordName || 'Unknown',
+      year: g2.team.league.year,
+      week: g2.week,
+      pointsScored: g2.pointsScored,
+      leagueName: g2.team.league.name,
+      result: r2,
+    });
+  }
+
+  const teamGameMap = new Map<string, GameResult[]>();
+  for (const result of gameResults) {
+    if (!teamGameMap.has(result.teamId)) teamGameMap.set(result.teamId, []);
+    teamGameMap.get(result.teamId)!.push(result);
+  }
+
+  for (const [, games] of teamGameMap) {
+    games.sort((a, b) => a.week - b.week);
+  }
+
+  interface StreakInfo {
+    userName: string;
+    year: number;
+    leagueName: string;
+    length: number;
+    startWeek: number;
+    endWeek: number;
+  }
+
+  function computeStreak(
+    games: GameResult[],
+    predicate: (g: GameResult) => boolean,
+  ): StreakInfo | null {
+    let maxLen = 0;
+    let currentLen = 0;
+    let maxStart = 0;
+    let maxEnd = 0;
+    let currentStart = 0;
+
+    for (let i = 0; i < games.length; i++) {
+      if (predicate(games[i])) {
+        if (currentLen === 0) currentStart = i;
+        currentLen++;
+        if (currentLen > maxLen) {
+          maxLen = currentLen;
+          maxStart = currentStart;
+          maxEnd = i;
+        }
+      } else {
+        currentLen = 0;
+      }
+    }
+
+    if (maxLen === 0) return null;
+    return {
+      userName: games[0].userName,
+      year: games[0].year,
+      leagueName: games[0].leagueName,
+      length: maxLen,
+      startWeek: games[maxStart].week,
+      endWeek: games[maxEnd].week,
+    };
+  }
+
+  const winStreaks: StreakInfo[] = [];
+  const lossStreaks: StreakInfo[] = [];
+  const streak100: StreakInfo[] = [];
+
+  for (const [, games] of teamGameMap) {
+    const ws = computeStreak(games, g => g.result === 'W');
+    if (ws) winStreaks.push(ws);
+
+    const ls = computeStreak(games, g => g.result === 'L');
+    if (ls) lossStreaks.push(ls);
+
+    const s100 = computeStreak(games, g => g.pointsScored >= 100);
+    if (s100) streak100.push(s100);
+  }
+
+  winStreaks.sort((a, b) => b.length - a.length);
+  lossStreaks.sort((a, b) => b.length - a.length);
+  streak100.sort((a, b) => b.length - a.length);
+
+  const makeStreakRows = (streaks: StreakInfo[]): RecordRow[] =>
+    streaks.slice(0, TOP_N).map(s => ({
+      cells: [
+        s.userName,
+        s.length.toString(),
+        `${s.year} W${s.startWeek}${s.startWeek !== s.endWeek ? `-W${s.endWeek}` : ''}`,
+        s.leagueName,
+      ],
+      leagueName: s.leagueName.toLowerCase(),
+    }));
+
+  return [
+    {
+      title: 'Longest Win Streak',
+      headers: ['Player', 'Games', 'Span', 'League'],
+      rows: makeStreakRows(winStreaks),
+    },
+    {
+      title: 'Longest Losing Streak',
+      headers: ['Player', 'Games', 'Span', 'League'],
+      rows: makeStreakRows(lossStreaks),
+    },
+    {
+      title: 'Longest 100+ Point Streak',
+      headers: ['Player', 'Games', 'Span', 'League'],
+      rows: makeStreakRows(streak100),
+    },
+  ];
+}

--- a/app/models/records.server.ts
+++ b/app/models/records.server.ts
@@ -140,11 +140,7 @@ export async function getCareerRecords(): Promise<RecordTable[]> {
         .sort((a, b) => b.pointsAgainst - a.pointsAgainst)
         .slice(0, TOP_N)
         .map(c => ({
-          cells: [
-            c.name,
-            c.pointsAgainst.toFixed(2),
-            c.seasons.toString(),
-          ],
+          cells: [c.name, c.pointsAgainst.toFixed(2), c.seasons.toString()],
         })),
     },
     {
@@ -204,17 +200,13 @@ export async function getSingleSeasonRecords(): Promise<RecordTable[]> {
     },
   });
 
-  const totalGames = (t: (typeof teams)[number]) =>
-    t.wins + t.losses + t.ties;
+  const totalGames = (t: (typeof teams)[number]) => t.wins + t.losses + t.ties;
   const winPct = (t: (typeof teams)[number]) =>
     totalGames(t) > 0 ? t.wins / totalGames(t) : 0;
   const differential = (t: (typeof teams)[number]) =>
     t.pointsFor - t.pointsAgainst;
 
-  const makeRow = (
-    t: (typeof teams)[number],
-    value: string,
-  ): RecordRow => ({
+  const makeRow = (t: (typeof teams)[number], value: string): RecordRow => ({
     cells: [
       t.user?.discordName || 'Unknown',
       value,
@@ -324,9 +316,7 @@ export async function getSingleGameRecords(): Promise<RecordTable[]> {
   ]);
 
   const makeRow = (
-    g:
-      | (typeof highestGames)[number]
-      | (typeof lowestGames)[number],
+    g: (typeof highestGames)[number] | (typeof lowestGames)[number],
   ): RecordRow => ({
     cells: [
       g.team.user?.discordName || 'Unknown',
@@ -561,10 +551,9 @@ export async function getStreakRecords(): Promise<RecordTable[]> {
       g1.pointsScored > g2.pointsScored
         ? 'W'
         : g1.pointsScored < g2.pointsScored
-          ? 'L'
-          : 'T';
-    const r2: 'W' | 'L' | 'T' =
-      r1 === 'W' ? 'L' : r1 === 'L' ? 'W' : 'T';
+        ? 'L'
+        : 'T';
+    const r2: 'W' | 'L' | 'T' = r1 === 'W' ? 'L' : r1 === 'L' ? 'W' : 'T';
 
     gameResults.push({
       teamId: g1.teamId,
@@ -665,7 +654,9 @@ export async function getStreakRecords(): Promise<RecordTable[]> {
       cells: [
         s.userName,
         s.length.toString(),
-        `${s.year} W${s.startWeek}${s.startWeek !== s.endWeek ? `-W${s.endWeek}` : ''}`,
+        `${s.year} W${s.startWeek}${
+          s.startWeek !== s.endWeek ? `-W${s.endWeek}` : ''
+        }`,
         s.leagueName,
       ],
       leagueName: s.leagueName.toLowerCase(),

--- a/app/routes/admin.registration-list.tsx
+++ b/app/routes/admin.registration-list.tsx
@@ -37,7 +37,8 @@ export const loader = async ({ request }: LoaderFunctionArgs) => {
 };
 
 export default function RegistrationList() {
-  const { registrations, notYetSignedUp, twoYearsAgoNotSignedUp } = useTypedLoaderData<typeof loader>();
+  const { registrations, notYetSignedUp, twoYearsAgoNotSignedUp } =
+    useTypedLoaderData<typeof loader>();
 
   return (
     <>

--- a/app/routes/admin.scheduler._index.tsx
+++ b/app/routes/admin.scheduler._index.tsx
@@ -108,7 +108,8 @@ export default function AdminSchedulerIndex() {
                     )}
                     {job.name === 'monitor-nfl-games' && (
                       <p className='text-sm text-gray-500 mt-1'>
-                        Monitors NFL games and triggers score resyncing when games finish
+                        Monitors NFL games and triggers score resyncing when
+                        games finish
                       </p>
                     )}
                   </div>

--- a/app/routes/admin.tsx
+++ b/app/routes/admin.tsx
@@ -1,13 +1,13 @@
 import type { LoaderFunctionArgs } from '@remix-run/node';
 import { Outlet } from '@remix-run/react';
 import { typedjson, useTypedLoaderData } from 'remix-typedjson';
+import { NavigationSection } from '~/components/layout/NavigationSection';
 import {
   authenticator,
   isAdmin,
   isPodcastEditor,
   requireEditor,
 } from '~/services/auth.server';
-import { NavigationSection } from '~/components/layout/NavigationSection';
 
 export const loader = async ({ request }: LoaderFunctionArgs) => {
   const user = await authenticator.isAuthenticated(request, {
@@ -29,7 +29,11 @@ export default function Admin() {
     useTypedLoaderData<typeof loader>();
 
   const leaguesLinks = [
-    { name: 'Registration List', href: '/admin/registration-list', current: false },
+    {
+      name: 'Registration List',
+      href: '/admin/registration-list',
+      current: false,
+    },
     { name: 'Seasons', href: '/admin/season', current: false },
     { name: 'Leagues', href: '/admin/leagues', current: false },
     { name: 'Cups', href: '/admin/cups', current: false },
@@ -46,7 +50,11 @@ export default function Admin() {
 
   const omniLinks = [
     { name: 'Score Update', href: '/admin/omni/scoring', current: false },
-    { name: 'Qualifying Points Update', href: '/admin/omni/qualifying-points', current: false },
+    {
+      name: 'Qualifying Points Update',
+      href: '/admin/omni/qualifying-points',
+      current: false,
+    },
     { name: 'Add Omni Player', href: '/admin/omni/add-player', current: false },
   ];
 
@@ -60,9 +68,7 @@ export default function Admin() {
     { name: 'Scheduler', href: '/admin/scheduler', current: false },
   ];
 
-  const botLinks = [
-    { name: 'Commands', href: '/admin/bot', current: false },
-  ];
+  const botLinks = [{ name: 'Commands', href: '/admin/bot', current: false }];
 
   const podcastLinks = [
     { name: 'List', href: '/admin/podcasts', current: false },
@@ -76,43 +82,43 @@ export default function Admin() {
         <div className='not-prose text-sm md:col-span-3'>
           {userIsAdmin && (
             <>
-              <NavigationSection 
-                title="Leagues" 
-                links={leaguesLinks} 
-                headingId="admin-leagues-heading" 
+              <NavigationSection
+                title='Leagues'
+                links={leaguesLinks}
+                headingId='admin-leagues-heading'
               />
-              <NavigationSection 
-                title="Games" 
-                links={gamesLinks} 
-                headingId="admin-members-games" 
+              <NavigationSection
+                title='Games'
+                links={gamesLinks}
+                headingId='admin-members-games'
               />
-              <NavigationSection 
-                title="Omni" 
-                links={omniLinks} 
-                headingId="admin-omni-heading" 
+              <NavigationSection
+                title='Omni'
+                links={omniLinks}
+                headingId='admin-omni-heading'
               />
-              <NavigationSection 
-                title="Members" 
-                links={membersLinks} 
-                headingId="admin-members-heading" 
+              <NavigationSection
+                title='Members'
+                links={membersLinks}
+                headingId='admin-members-heading'
               />
-              <NavigationSection 
-                title="Data" 
-                links={dataLinks} 
-                headingId="admin-data-heading" 
+              <NavigationSection
+                title='Data'
+                links={dataLinks}
+                headingId='admin-data-heading'
               />
-              <NavigationSection 
-                title="Bot" 
-                links={botLinks} 
-                headingId="admin-bot-heading" 
+              <NavigationSection
+                title='Bot'
+                links={botLinks}
+                headingId='admin-bot-heading'
               />
             </>
           )}
           {userIsPodcastEditor && (
-            <NavigationSection 
-              title="Podcast" 
-              links={podcastLinks} 
-              headingId="admin-podcast-heading" 
+            <NavigationSection
+              title='Podcast'
+              links={podcastLinks}
+              headingId='admin-podcast-heading'
             />
           )}
         </div>
@@ -125,7 +131,7 @@ export default function Admin() {
 }
 
 export function ErrorBoundary({ error }: { error: Error }) {
-  console.error({error});
+  console.error({ error });
   // Don't forget to typecheck with your own logic.
   // Any value can be thrown, not just errors!
   let errorMessage = 'Unknown error';

--- a/app/routes/games.qb-streaming.entries.$id.test.tsx
+++ b/app/routes/games.qb-streaming.entries.$id.test.tsx
@@ -1,12 +1,12 @@
 import { action } from './games.qb-streaming.entries.$id';
 import type { ActionFunctionArgs } from '@remix-run/node';
 import { describe, expect, it, vi, beforeEach, afterAll } from 'vitest';
+import { prisma } from '~/db.server';
 import * as nflGameModel from '~/models/nflgame.server';
 import * as qbSelectionModel from '~/models/qbselection.server';
 import * as qbStreamingWeekModel from '~/models/qbstreamingweek.server';
 import type { User } from '~/models/user.server';
 import * as auth from '~/services/auth.server';
-import { prisma } from '~/db.server';
 
 // Mock all dependencies
 vi.mock('~/services/auth.server', () => ({

--- a/app/routes/games.qb-streaming.entries.$id.tsx
+++ b/app/routes/games.qb-streaming.entries.$id.tsx
@@ -65,7 +65,11 @@ export const action = async ({ params, request }: ActionFunctionArgs) => {
       option => option.id === submittedPlayerId,
     );
     if (!qbStreamingOption) {
-      throw new Error(`${selectionType === 'standard' ? 'Standard' : 'Deep'} QB Streaming Option not found`);
+      throw new Error(
+        `${
+          selectionType === 'standard' ? 'Standard' : 'Deep'
+        } QB Streaming Option not found`,
+      );
     }
 
     const nflGame = await getNflGameById(qbStreamingOption.nflGameId);
@@ -145,8 +149,7 @@ export default function QBStreamingYearWeekEntry() {
     !!qbSelection &&
     qbSelection?.standardPlayer.nflGame.gameStartTime < new Date();
   const deepIsLocked =
-    !!qbSelection &&
-    qbSelection?.deepPlayer.nflGame.gameStartTime < new Date();
+    !!qbSelection && qbSelection?.deepPlayer.nflGame.gameStartTime < new Date();
 
   return (
     <>

--- a/app/routes/games.qb-streaming.rules.tsx
+++ b/app/routes/games.qb-streaming.rules.tsx
@@ -14,7 +14,10 @@ export default function GamesQBStreamingRules() {
         <li>-2 per interception/fumble</li>
         <li>2 per 2-point conversion</li>
       </ul>
-      <p>Highest total from your best 12 weekly scores at the end of the season wins.</p>
+      <p>
+        Highest total from your best 12 weekly scores at the end of the season
+        wins.
+      </p>
     </>
   );
 }

--- a/app/routes/games.tsx
+++ b/app/routes/games.tsx
@@ -1,11 +1,11 @@
 import { Outlet } from '@remix-run/react';
 import { typedjson, useTypedLoaderData } from 'remix-typedjson';
+import { NavigationSection } from '~/components/layout/NavigationSection';
 import { prisma } from '~/db.server';
 import { getLocksWeeksByYear } from '~/models/locksweek.server';
 import { getPoolWeeksByYear } from '~/models/poolweek.server';
 import { getQBStreamingWeeks } from '~/models/qbstreamingweek.server';
 import { getCurrentSeason } from '~/models/season.server';
-import { NavigationSection } from '~/components/layout/NavigationSection';
 
 const navigationLinks = [
   { name: 'F²', href: '/games/f-squared', current: false },
@@ -138,29 +138,29 @@ export default function GamesIndex() {
       <h2>FlexSpotFF Games</h2>
       <div className='grid md:grid-cols-12 md:gap-4'>
         <div className='not-prose text-sm md:col-span-2'>
-          <NavigationSection 
-            title="Games" 
-            links={navigationLinks} 
-            headingId="admin-leagues-heading" 
+          <NavigationSection
+            title='Games'
+            links={navigationLinks}
+            headingId='admin-leagues-heading'
           />
-          <NavigationSection 
-            title="Spread Pool" 
-            links={spreadPoolLinks} 
-            headingId="games-spreadPool-heading" 
+          <NavigationSection
+            title='Spread Pool'
+            links={spreadPoolLinks}
+            headingId='games-spreadPool-heading'
           />
-          <NavigationSection 
-            title="QB Streaming Challenge" 
-            links={qbStreamingLinks} 
+          <NavigationSection
+            title='QB Streaming Challenge'
+            links={qbStreamingLinks}
           />
-          <NavigationSection 
-            title="Locks Challenge" 
-            links={nflLocksChallengeLinks} 
-            headingId="games-locksChallenge-heading" 
+          <NavigationSection
+            title='Locks Challenge'
+            links={nflLocksChallengeLinks}
+            headingId='games-locksChallenge-heading'
           />
-          <NavigationSection 
-            title="DFS Survivor" 
-            links={dfsSurvivorLinks} 
-            headingId="games-dfssurvivor-heading" 
+          <NavigationSection
+            title='DFS Survivor'
+            links={dfsSurvivorLinks}
+            headingId='games-dfssurvivor-heading'
           />
         </div>
         <div className='md:col-span-10'>

--- a/app/routes/leagues.records.tsx
+++ b/app/routes/leagues.records.tsx
@@ -1,4 +1,7 @@
+import clsx from 'clsx';
+import { useState } from 'react';
 import { typedjson, useTypedLoaderData } from 'remix-typedjson';
+import RecordsTable from '~/components/layout/records/RecordsTable';
 import type { RecordTable } from '~/models/records.server';
 import {
   getCareerRecords,
@@ -7,9 +10,6 @@ import {
   getSingleSeasonRecords,
   getStreakRecords,
 } from '~/models/records.server';
-import clsx from 'clsx';
-import { useState } from 'react';
-import RecordsTable from '~/components/layout/records/RecordsTable';
 
 const CATEGORIES = [
   { key: 'career', label: 'Career' },

--- a/app/routes/leagues.records.tsx
+++ b/app/routes/leagues.records.tsx
@@ -1,3 +1,116 @@
+import { typedjson, useTypedLoaderData } from 'remix-typedjson';
+import type { RecordTable } from '~/models/records.server';
+import {
+  getCareerRecords,
+  getCupRecords,
+  getSingleGameRecords,
+  getSingleSeasonRecords,
+  getStreakRecords,
+} from '~/models/records.server';
+import clsx from 'clsx';
+import { useState } from 'react';
+import RecordsTable from '~/components/layout/records/RecordsTable';
+
+const CATEGORIES = [
+  { key: 'career', label: 'Career' },
+  { key: 'season', label: 'Single Season' },
+  { key: 'game', label: 'Single Game' },
+  { key: 'cup', label: 'Cup' },
+  { key: 'streaks', label: 'Streaks' },
+] as const;
+
+type CategoryKey = (typeof CATEGORIES)[number]['key'];
+
+export const loader = async () => {
+  const [
+    careerRecords,
+    singleSeasonRecords,
+    singleGameRecords,
+    cupRecords,
+    streakRecords,
+  ] = await Promise.all([
+    getCareerRecords(),
+    getSingleSeasonRecords(),
+    getSingleGameRecords(),
+    getCupRecords(),
+    getStreakRecords(),
+  ]);
+
+  return typedjson({
+    careerRecords,
+    singleSeasonRecords,
+    singleGameRecords,
+    cupRecords,
+    streakRecords,
+  });
+};
+
 export default function Records() {
-  return <div>To be populated once Chris gets his act together.</div>;
+  const data = useTypedLoaderData<typeof loader>();
+  const [category, setCategory] = useState<CategoryKey>('career');
+  const [tableIndex, setTableIndex] = useState(0);
+
+  const tablesMap: Record<CategoryKey, RecordTable[]> = {
+    career: data.careerRecords,
+    season: data.singleSeasonRecords,
+    game: data.singleGameRecords,
+    cup: data.cupRecords,
+    streaks: data.streakRecords,
+  };
+
+  const tables = tablesMap[category];
+  const currentTable = tables[tableIndex] ?? tables[0];
+
+  const handleCategoryChange = (key: CategoryKey) => {
+    setCategory(key);
+    setTableIndex(0);
+  };
+
+  return (
+    <>
+      <h2>Record Books</h2>
+
+      <div className='not-prose my-4 flex flex-wrap gap-2'>
+        {CATEGORIES.map(cat => (
+          <button
+            key={cat.key}
+            type='button'
+            onClick={() => handleCategoryChange(cat.key)}
+            className={clsx(
+              'rounded-md px-4 py-2 text-sm font-medium transition-colors',
+              category === cat.key
+                ? 'bg-white text-gray-900 shadow'
+                : 'bg-gray-700 text-gray-300 hover:bg-gray-600',
+            )}
+          >
+            {cat.label}
+          </button>
+        ))}
+      </div>
+
+      {tables.length > 1 && (
+        <div className='not-prose mb-6'>
+          <select
+            value={tableIndex}
+            onChange={e => setTableIndex(Number(e.target.value))}
+            className='rounded-md bg-gray-800 px-3 py-2 text-sm text-white border border-gray-600 focus:outline-none focus:ring-2 focus:ring-white'
+          >
+            {tables.map((t, i) => (
+              <option key={i} value={i}>
+                {t.title}
+              </option>
+            ))}
+          </select>
+        </div>
+      )}
+
+      {currentTable && (
+        <RecordsTable
+          title={currentTable.title}
+          headers={currentTable.headers}
+          rows={currentTable.rows}
+        />
+      )}
+    </>
+  );
 }

--- a/app/routes/leagues.rules.tsx
+++ b/app/routes/leagues.rules.tsx
@@ -27,15 +27,15 @@ export default function RulesPage() {
       <h3 id='3-membership'>3. Membership</h3>
 
       <p>
-        3.1. The Flex Spot Football Club is a public set of leagues. In order to join the
-        Club, you must be a member of the Flex Spot Football server throughout the
-        season.
+        3.1. The Flex Spot Football Club is a public set of leagues. In order to
+        join the Club, you must be a member of the Flex Spot Football server
+        throughout the season.
       </p>
 
       <p>
-        3.1a. The majority of communication for the Flex Spot Football Club is done
-        through the Discord server. It is expected that members are reasonably
-        active and responsive to inquiries through the server.
+        3.1a. The majority of communication for the Flex Spot Football Club is
+        done through the Discord server. It is expected that members are
+        reasonably active and responsive to inquiries through the server.
       </p>
 
       <p>
@@ -318,9 +318,9 @@ export default function RulesPage() {
         10.4. Empty lineup slots are permitted for strategic purposes. Examples
         include, but not limited to: benching a Monday night player when they
         are ahead of their opponent who does not have any more active players,
-        not playing a defense because they don’t want to drop a player, playing a
-        player on bye because they don’t want to drop a player. Players that are
-        going to play an empty lineup spot for strategic purposes need to
+        not playing a defense because they don’t want to drop a player, playing
+        a player on bye because they don’t want to drop a player. Players that
+        are going to play an empty lineup spot for strategic purposes need to
         declare their intent to a Commissioner or in the main FFDiscord Club
         channel.
       </p>
@@ -449,10 +449,10 @@ export default function RulesPage() {
       <h3 id='14-league-hierarchy'>14. League Hierarchy</h3>
 
       <p>
-        14.1. The Flex Spot Football Club is distributed into two “tiers”: Tier One, and
-        Tier Two. Tier One consists of a single 12-member league, known as the
-        Champions League. Tier Two consists of multiple 12-member leagues, and
-        can vary in quantity of leagues from season to season.
+        14.1. The Flex Spot Football Club is distributed into two “tiers”: Tier
+        One, and Tier Two. Tier One consists of a single 12-member league, known
+        as the Champions League. Tier Two consists of multiple 12-member
+        leagues, and can vary in quantity of leagues from season to season.
       </p>
 
       <p>

--- a/app/routes/leagues.tsx
+++ b/app/routes/leagues.tsx
@@ -1,8 +1,8 @@
 import { Outlet } from '@remix-run/react';
 import { typedjson, useTypedLoaderData } from 'remix-typedjson';
+import { NavigationSection } from '~/components/layout/NavigationSection';
 import { getCurrentSeason } from '~/models/season.server';
 import { getNewestWeekTeamGameByYear } from '~/models/teamgame.server';
-import { NavigationSection } from '~/components/layout/NavigationSection';
 
 export const loader = async () => {
   let currentSeason = await getCurrentSeason();
@@ -46,10 +46,10 @@ export default function LeaguesIndex() {
       <h2>FlexSpotFF Leagues</h2>
       <div className='grid md:grid-cols-12 md:gap-4'>
         <div className='not-prose text-sm md:col-span-2'>
-          <NavigationSection 
-            title="Leagues" 
-            links={navigationLinks} 
-            headingId="admin-leagues-heading" 
+          <NavigationSection
+            title='Leagues'
+            links={navigationLinks}
+            headingId='admin-leagues-heading'
           />
         </div>
         <div className='md:col-span-10'>

--- a/app/services/scheduler.server.ts
+++ b/app/services/scheduler.server.ts
@@ -9,13 +9,15 @@ export class SchedulerService {
 
   constructor() {
     const isProduction = process.env.NODE_ENV === 'production';
-    const jobsRoot = isProduction ? path.join(process.cwd(), 'build/jobs') : path.join(process.cwd(), 'jobs');
+    const jobsRoot = isProduction
+      ? path.join(process.cwd(), 'build/jobs')
+      : path.join(process.cwd(), 'jobs');
     const jobExtension = isProduction ? 'cjs' : 'ts';
-    
+
     console.log(`Scheduler Environment: ${process.env.NODE_ENV}`);
     console.log(`Jobs Root: ${jobsRoot}`);
     console.log(`Job Extension: ${jobExtension}`);
-    
+
     this.bree = new Bree({
       root: jobsRoot,
       defaultExtension: jobExtension,

--- a/app/utils/types.ts
+++ b/app/utils/types.ts
@@ -7,12 +7,16 @@ export type ArrElement<ArrType> = ArrType extends readonly (infer ElementType)[]
 
 // Shared type guards for action data validation
 // Type guard to check if action data is a success response with message
-export function isSuccessWithMessage(actionData: any): actionData is { success: true; message: string } {
+export function isSuccessWithMessage(
+  actionData: any,
+): actionData is { success: true; message: string } {
   return actionData?.success === true && 'message' in actionData;
 }
 
 // Type guard to check if action data is an error response
-export function isErrorResponse(actionData: any): actionData is { success: false; error: any } {
+export function isErrorResponse(
+  actionData: any,
+): actionData is { success: false; error: any } {
   return actionData?.success === false && 'error' in actionData;
 }
 

--- a/bot/utils.ts
+++ b/bot/utils.ts
@@ -125,7 +125,9 @@ export const setUserRole = async ({
 
   try {
     await rest.put(Routes.guildMemberRole(guildId, userId, roleId));
-    console.log(`Successfully assigned role ${roleId} to user ${userId} in guild ${guildId}`);
+    console.log(
+      `Successfully assigned role ${roleId} to user ${userId} in guild ${guildId}`,
+    );
   } catch (error) {
     console.error('Error setting user role:', error);
     throw error;

--- a/jobs/sync-leagues.ts
+++ b/jobs/sync-leagues.ts
@@ -1,7 +1,7 @@
-import { parentPort } from 'worker_threads';
 import { syncMultipleLeagues } from '../app/libs/league-sync.server.js';
 import { getLeaguesByYear } from '../app/models/league.server.js';
 import { getCurrentSeason } from '../app/models/season.server.js';
+import { parentPort } from 'worker_threads';
 
 /**
  * Job to sync all leagues in the current season
@@ -10,7 +10,7 @@ import { getCurrentSeason } from '../app/models/season.server.js';
 async function syncLeaguesJob() {
   try {
     console.log('Starting leagues sync job...');
-    
+
     // Get current season
     const currentSeason = await getCurrentSeason();
     if (!currentSeason) {
@@ -24,7 +24,9 @@ async function syncLeaguesJob() {
     console.log(`Found ${leagues.length} leagues to sync`);
 
     // Sync all leagues using shared function
-    const { syncedCount, errorCount, errors } = await syncMultipleLeagues(leagues);
+    const { syncedCount, errorCount, errors } = await syncMultipleLeagues(
+      leagues,
+    );
 
     const message = `Leagues sync completed: ${syncedCount} successful, ${errorCount} failed`;
     console.log(message);
@@ -38,27 +40,26 @@ async function syncLeaguesJob() {
 
     // Send success message to parent
     if (parentPort) {
-      parentPort.postMessage({ 
-        success: true, 
+      parentPort.postMessage({
+        success: true,
         message,
         syncedCount,
         errorCount,
         totalLeagues: leagues.length,
-        errors
+        errors,
+      });
+    }
+  } catch (error) {
+    console.error('Leagues sync job failed:', error);
+
+    // Send error message to parent
+    if (parentPort) {
+      parentPort.postMessage({
+        success: false,
+        error: error instanceof Error ? error.message : 'Unknown error',
       });
     }
 
-  } catch (error) {
-    console.error('Leagues sync job failed:', error);
-    
-    // Send error message to parent
-    if (parentPort) {
-      parentPort.postMessage({ 
-        success: false, 
-        error: error instanceof Error ? error.message : 'Unknown error' 
-      });
-    }
-    
     // Exit with error code
     process.exit(1);
   }

--- a/jobs/sync-nfl-players.ts
+++ b/jobs/sync-nfl-players.ts
@@ -1,5 +1,5 @@
-import { parentPort } from 'worker_threads';
 import { syncNflPlayers } from '../app/libs/syncs.server.js';
+import { parentPort } from 'worker_threads';
 
 /**
  * Job to sync NFL players database
@@ -10,22 +10,25 @@ async function syncNflPlayersJob() {
     console.log('Starting NFL players sync job...');
     await syncNflPlayers();
     console.log('NFL players sync job completed successfully');
-    
+
     // Send success message to parent
     if (parentPort) {
-      parentPort.postMessage({ success: true, message: 'NFL players synced successfully' });
+      parentPort.postMessage({
+        success: true,
+        message: 'NFL players synced successfully',
+      });
     }
   } catch (error) {
     console.error('NFL players sync job failed:', error);
-    
+
     // Send error message to parent
     if (parentPort) {
-      parentPort.postMessage({ 
-        success: false, 
-        error: error instanceof Error ? error.message : 'Unknown error' 
+      parentPort.postMessage({
+        success: false,
+        error: error instanceof Error ? error.message : 'Unknown error',
       });
     }
-    
+
     // Exit with error code
     process.exit(1);
   }

--- a/jobs/tsup.config.ts
+++ b/jobs/tsup.config.ts
@@ -14,10 +14,7 @@ export default defineConfig({
   minify: false,
   splitting: false,
   bundle: true,
-  external: [
-    '@prisma/client',
-    'prisma'
-  ],
+  external: ['@prisma/client', 'prisma'],
   // Use .cjs extension for CommonJS in ESM project
   outExtension: () => ({ js: '.cjs' }),
 });

--- a/scheduler/server.ts
+++ b/scheduler/server.ts
@@ -1,5 +1,5 @@
-import 'dotenv/config';
 import { scheduler } from '../app/services/scheduler.server.js';
+import 'dotenv/config';
 
 /**
  * FlexSpot FF Scheduler Service
@@ -16,14 +16,14 @@ async function shutdown() {
   isShuttingDown = true;
 
   console.log('\n🛑 Shutting down scheduler...');
-  
+
   try {
     await scheduler.stop();
     console.log('✅ Scheduler stopped gracefully');
   } catch (error) {
     console.error('❌ Error stopping scheduler:', error);
   }
-  
+
   process.exit(0);
 }
 
@@ -31,7 +31,7 @@ async function shutdown() {
 process.on('SIGINT', shutdown);
 process.on('SIGTERM', shutdown);
 
-process.on('uncaughtException', async (error) => {
+process.on('uncaughtException', async error => {
   console.error('💥 Uncaught Exception:', error);
   await shutdown();
 });
@@ -46,13 +46,13 @@ async function startScheduler() {
   try {
     await scheduler.start();
     console.log('✅ Scheduler started successfully');
-    
+
     const jobs = scheduler.getJobs();
     console.log('📋 Active Jobs:');
     jobs.forEach((job: any) => {
       console.log(`   • ${job.name}: ${job.cron || 'No schedule'}`);
     });
-    
+
     console.log('🚀 Scheduler running in background...');
   } catch (error) {
     console.error('❌ Failed to start scheduler:', error);

--- a/scheduler/tsconfig.json
+++ b/scheduler/tsconfig.json
@@ -10,10 +10,6 @@
     "module": "ES2022",
     "skipLibCheck": true
   },
-  "include": [
-    "**/*.ts"
-  ],
-  "exclude": [
-    "node_modules"
-  ]
+  "include": ["**/*.ts"],
+  "exclude": ["node_modules"]
 }

--- a/scheduler/tsup.config.ts
+++ b/scheduler/tsup.config.ts
@@ -11,8 +11,5 @@ export default defineConfig({
   minify: false,
   splitting: false,
   bundle: true,
-  external: [
-    '@prisma/client',
-    'prisma'
-  ],
+  external: ['@prisma/client', 'prisma'],
 });


### PR DESCRIPTION
## Summary

- Adds a new Record Books page at `/leagues/records` with five categories: Career, Single Season, Single Game, Cup, and Streaks
- Each category has multiple leaderboard tables selectable via dropdown; all show top 50 entries
- Rank badges are colored by league affiliation where applicable (falls back to gray for career-aggregate records)

## Notable fixes

- **Streak data was silently empty** due to `sleeperMatchupId` values repeating each week (Sleeper reuses IDs 1, 2, 3… per week). The matchup grouping key now includes `week` (`leagueId:week:matchupId`) so each matchup is correctly identified as a two-team pair.
- **Rank badge padding** — removed the fixed `w-10` column width that caused the 32px badge to overflow its cell and ignore padding.
- **Null safety** — `currentTable` is guarded before rendering so an empty category doesn't crash the page.

## Test plan

- [ ] Visit `/leagues/records` and verify all five category tabs load with data
- [ ] Confirm Streaks tab shows win/loss/100+ point streak leaderboards with rows
- [ ] Confirm Cup tab shows Championships, Finals Appearances, and Game Wins only
- [ ] Confirm Single Season tab does not show Avg PF/Week or Median Win %
- [ ] Verify rank badges have visible left padding and are not flush to the table edge

🤖 Generated with [Claude Code](https://claude.com/claude-code)