### PR TITLE
Remove "Most Career Losses" record table from career records

### DIFF
--- a/app/models/records.server.ts
+++ b/app/models/records.server.ts
@@ -88,21 +88,6 @@ export async function getCareerRecords(): Promise<RecordTable[]> {
         })),
     },
     {
-      title: 'Most Career Losses',
-      headers: ['Player', 'Losses', 'Record', 'Seasons'],
-      rows: [...careers]
-        .sort((a, b) => b.losses - a.losses)
-        .slice(0, TOP_N)
-        .map(c => ({
-          cells: [
-            c.name,
-            c.losses.toString(),
-            `${c.wins}-${c.losses}-${c.ties}`,
-            c.seasons.toString(),
-          ],
-        })),
-    },
-    {
       title: 'Highest Career Win Percentage',
       headers: ['Player', 'Win %', 'Record', 'Seasons'],
       rows: [...careers]


### PR DESCRIPTION
## Summary
Removed the "Most Career Losses" record table from the career records display.

## Changes
- Deleted the "Most Career Losses" table configuration from `getCareerRecords()` function
- This table displayed the top players sorted by total career losses along with their win-loss-tie record and seasons played

## Rationale
The removal of this record table suggests a shift in focus toward more meaningful career statistics. The "Most Career Losses" metric is less relevant for recognizing player achievements compared to other career records like wins, win percentage, and games played.

https://claude.ai/code/session_01MUb1m2QuzTUcxuv6neGe9n