### PR TITLE
feat: add shared test database sync for easier dev onboarding

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -15,8 +15,10 @@ SESSION_SECRET="super-duper-s3cret"
 WEBSITE_URL="http://localhost:5173"
 SPREADS_API_KEY="PUT_KEY_HERE"
 DEV_GUILD_ID="channel ID of where you test commands"
-OMNI_CHANNEL_ID="channel ID of where you want omni notifications to go"
 TIME_MOCK_SECRET="random string that matches in cypress config file"
-OMNI_ROLE_ID="role ID of where you want group omni notifications to go"
-LEAGUE_ANNOUNCEMENT_CHANNEL_ID="channel ID of where you want league notifications to go"
+# Leave these unset locally — without them, no Discord notifications will fire
+# when using admin routes against the shared test database
+# OMNI_CHANNEL_ID="channel ID of where you want omni notifications to go"
+# OMNI_ROLE_ID="role ID of where you want group omni notifications to go"
+# LEAGUE_ANNOUNCEMENT_CHANNEL_ID="channel ID of where you want league notifications to go"
 FFDISCORDADMIN_SLEEPER_ID=329096543967641600

--- a/README.md
+++ b/README.md
@@ -13,6 +13,38 @@ the [Remix documentation](https://remix.run/docs/en/main) is your best bet.
   npm install
   ```
 
+- Copy `.env.example` to `.env`.
+
+There are two ways to get a working database. **Option A** (shared test DB) is
+recommended for most new contributors.
+
+#### Option A — Shared test database (recommended)
+
+Ask Chris for the `DATABASE_URL` for the shared `flexspotff_test` database and
+set it in your `.env`. You can skip the Docker and database-sync steps entirely.
+
+Update these values in `.env`:
+
+- `DATABASE_URL`: use the connection string provided by Chris
+- `DISCORD_CLIENT_ID`: go to discord.com/developers, create an application, and
+  use the client ID from the OAuth2 tab
+- `DISCORD_SECRET`: client secret from the same page
+- `SESSION_SECRET`: optional, sets the session encryption string
+
+> **Important:** Leave `OMNI_CHANNEL_ID`, `OMNI_ROLE_ID`, and
+> `LEAGUE_ANNOUNCEMENT_CHANNEL_ID` unset (they are commented out in
+> `.env.example`). Without these, no Discord notifications will fire if you use
+> admin routes while developing.
+
+Then run migrations and start the dev server:
+
+```sh
+npm run setup
+npm run dev
+```
+
+#### Option B — Local Docker database
+
 - Start the Postgres Database in [Docker](https://www.docker.com/get-started):
 
   ```sh
@@ -23,15 +55,12 @@ the [Remix documentation](https://remix.run/docs/en/main) is your best bet.
   > the background. Ensure that Docker has finished and your container is
   > running before proceeding.
 
-- Copy .env.example to .env, and update the following:
+- Update `.env`:
 
-  - DATABASE_URL to remove the \_test at the end, as that's used for the testing
-    pipeline
-  - DISCORD_CLIENT_ID: Go to discord.com/developers, create an application, and
-    then under the OAuth2 tab in settings, use the client ID
-  - DISCORD_SECRET: On the same page as above, use the client secret (you may
-    need to reset yours)
-  - SESSION_SECRET: Not required but does set a different string for encrypting
+  - `DATABASE_URL`: remove the `_test` suffix (that's used for the testing
+    pipeline)
+  - `DISCORD_CLIENT_ID`, `DISCORD_SECRET`: see Option A above
+  - `SESSION_SECRET`: optional
 
 - While you're in the discord developer settings, you'll also want to set
   redirects to the following if you want to test Discord authentication
@@ -72,14 +101,19 @@ http://localhost:5173/auth/discord/callback
 
 This starts your app in development mode, rebuilding assets on file changes.
 
-If you'd prefer not to use Docker, you can also use Fly's Wireguard VPN to
-connect to a development database (or even your production database). You can
-find the instructions to set up Wireguard
-[here](https://fly.io/docs/reference/private-networking/#install-your-wireguard-app),
-and the instructions for creating a development database
-[here](https://fly.io/docs/reference/postgres/).
-
 ## Database syncing
+
+### Syncing production to the shared test database
+
+To refresh the shared `flexspotff_test` database from production, use the button
+on the `/admin/data` page ("Sync Test Database from Production"), or run this
+from the server:
+
+```sh
+npm run db:sync-prod-to-test
+```
+
+### Restoring a backup to a local Docker database
 
 Assuming you have a backup database to load and are using docker, you can use
 the db-sync npm script to handle this.

--- a/app/routes/admin.data._index.tsx
+++ b/app/routes/admin.data._index.tsx
@@ -104,22 +104,44 @@ export const action = async ({ request }: ActionFunctionArgs) => {
 
       try {
         await execFileAsync('docker', [
-          'exec', '-i', 'postgres', 'psql', '-U', dbUser, '-c',
+          'exec',
+          '-i',
+          'postgres',
+          'psql',
+          '-U',
+          dbUser,
+          '-c',
           `SELECT pg_terminate_backend(pid) FROM pg_stat_activity WHERE datname = '${testDb}' AND pid <> pg_backend_pid();`,
         ]);
         await execFileAsync('docker', [
-          'exec', '-i', 'postgres', 'psql', '-U', dbUser, '-c',
+          'exec',
+          '-i',
+          'postgres',
+          'psql',
+          '-U',
+          dbUser,
+          '-c',
           `DROP DATABASE IF EXISTS ${testDb};`,
         ]);
         await execFileAsync('docker', [
-          'exec', '-i', 'postgres', 'psql', '-U', dbUser, '-c',
+          'exec',
+          '-i',
+          'postgres',
+          'psql',
+          '-U',
+          dbUser,
+          '-c',
           `CREATE DATABASE ${testDb} OWNER ${dbUser};`,
         ]);
         // Pipe requires a shell; single-quote values to prevent injection
         const safeUser = dbUser.replace(/'/g, "'\\''");
         const safeProdDb = prodDb.replace(/'/g, "'\\''");
         await execFileAsync('docker', [
-          'exec', '-i', 'postgres', 'bash', '-c',
+          'exec',
+          '-i',
+          'postgres',
+          'bash',
+          '-c',
           `pg_dump -U '${safeUser}' '${safeProdDb}' | psql -U '${safeUser}' -d '${testDb}'`,
         ]);
       } catch (e) {
@@ -269,11 +291,10 @@ export default function AdminDataIndex() {
         <section>
           <h3>Sync Test Database</h3>
           <p>
-            Copies the production database to{' '}
-            <code>flexspotff_test</code> so developers can point their
-            local apps at the shared test database instead of running
-            Docker. This will overwrite all existing data in the test
-            database.
+            Copies the production database to <code>flexspotff_test</code> so
+            developers can point their local apps at the shared test database
+            instead of running Docker. This will overwrite all existing data in
+            the test database.
           </p>
           <Button
             type='submit'

--- a/app/routes/admin.data._index.tsx
+++ b/app/routes/admin.data._index.tsx
@@ -92,6 +92,45 @@ export const action = async ({ request }: ActionFunctionArgs) => {
         message: `League games have been synced for ${year}.`,
       });
     }
+    case 'syncTestDatabase': {
+      const { execFile } = await import('child_process');
+      const { promisify } = await import('util');
+      const execFileAsync = promisify(execFile);
+
+      const url = new URL(process.env.DATABASE_URL!);
+      const dbUser = url.username;
+      const prodDb = url.pathname.slice(1);
+      const testDb = 'flexspotff_test';
+
+      try {
+        await execFileAsync('docker', [
+          'exec', '-i', 'postgres', 'psql', '-U', dbUser, '-c',
+          `SELECT pg_terminate_backend(pid) FROM pg_stat_activity WHERE datname = '${testDb}' AND pid <> pg_backend_pid();`,
+        ]);
+        await execFileAsync('docker', [
+          'exec', '-i', 'postgres', 'psql', '-U', dbUser, '-c',
+          `DROP DATABASE IF EXISTS ${testDb};`,
+        ]);
+        await execFileAsync('docker', [
+          'exec', '-i', 'postgres', 'psql', '-U', dbUser, '-c',
+          `CREATE DATABASE ${testDb} OWNER ${dbUser};`,
+        ]);
+        // Pipe requires a shell; single-quote values to prevent injection
+        const safeUser = dbUser.replace(/'/g, "'\\''");
+        const safeProdDb = prodDb.replace(/'/g, "'\\''");
+        await execFileAsync('docker', [
+          'exec', '-i', 'postgres', 'bash', '-c',
+          `pg_dump -U '${safeUser}' '${safeProdDb}' | psql -U '${safeUser}' -d '${testDb}'`,
+        ]);
+      } catch (e) {
+        const message = e instanceof Error ? e.message : String(e);
+        return json<ActionData>({ formError: `Sync failed: ${message}` });
+      }
+
+      return json<ActionData>({
+        message: 'Test database has been synced from production.',
+      });
+    }
   }
 
   return json<ActionData>({ message: 'Nothing was updated.' });
@@ -225,6 +264,24 @@ export default function AdminDataIndex() {
             disabled={navigation.state !== 'idle'}
           >
             Resync NFL Players
+          </Button>
+        </section>
+        <section>
+          <h3>Sync Test Database</h3>
+          <p>
+            Copies the production database to{' '}
+            <code>flexspotff_test</code> so developers can point their
+            local apps at the shared test database instead of running
+            Docker. This will overwrite all existing data in the test
+            database.
+          </p>
+          <Button
+            type='submit'
+            name='_action'
+            value='syncTestDatabase'
+            disabled={navigation.state !== 'idle'}
+          >
+            Sync Test Database from Production
           </Button>
         </section>
       </Form>

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "db:migrate:dev": "npx prisma migrate dev",
     "db:migrate:test": "dotenv -e .env.test -- npx prisma db push --accept-data-loss",
     "db-sync": "scripts/db-sync.sh",
+    "db:sync-prod-to-test": "scripts/db-sync-prod-to-test.sh",
     "dev": "remix vite:dev",
     "dev:all": "run-p dev dev:bot dev:scheduler",
     "dev:bot": "tsx watch bot/server.ts",

--- a/scripts/db-sync-prod-to-test.sh
+++ b/scripts/db-sync-prod-to-test.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+set -e
+
+scriptDir=$(dirname -- "$(readlink -f -- "$BASH_SOURCE")")
+cd "$scriptDir"/..
+
+source .env
+
+url="$DATABASE_URL"
+DB_USER=$(echo "$url" | sed 's|postgresql://||' | awk -F'[:@]' '{print $1}')
+PROD_DB=$(echo "$url" | awk -F'/' '{print $NF}' | awk -F'?' '{print $1}')
+TEST_DB="flexspotff_test"
+
+echo "Syncing $PROD_DB → $TEST_DB..."
+
+docker exec -i postgres psql -U "$DB_USER" -c \
+  "SELECT pg_terminate_backend(pid) FROM pg_stat_activity WHERE datname = '$TEST_DB' AND pid <> pg_backend_pid();"
+docker exec -i postgres psql -U "$DB_USER" -c "DROP DATABASE IF EXISTS $TEST_DB;"
+docker exec -i postgres psql -U "$DB_USER" -c "CREATE DATABASE $TEST_DB OWNER $DB_USER;"
+docker exec -i postgres bash -c "pg_dump -U $DB_USER $PROD_DB | psql -U $DB_USER -d $TEST_DB"
+
+echo "Sync complete."


### PR DESCRIPTION
## Summary

- Adds a **Sync Test Database from Production** button to `/admin/data` that copies the prod DB to `flexspotff_test` so developers can point their local apps at the hosted test DB instead of running Docker or managing backup files
- Adds `scripts/db-sync-prod-to-test.sh` and `npm run db:sync-prod-to-test` for triggering the same sync from the server CLI
- Updates README with an **Option A** (shared test DB) onboarding path alongside the existing Docker path
- Comments out `OMNI_CHANNEL_ID`, `OMNI_ROLE_ID`, and `LEAGUE_ANNOUNCEMENT_CHANNEL_ID` in `.env.example` so local dev against the test DB cannot accidentally ping Discord users

## Security / correctness notes

- First three `docker exec` commands use `execFile` with an args array — no shell involvement, no injection surface
- The `pg_dump | psql` pipe (which requires a shell) single-quotes `dbUser` and `prodDb` after escaping embedded single quotes
- `execFileAsync` (async) replaces `execSync` so the Node event loop is not blocked during the dump
- The whole sequence is wrapped in try/catch and surfaces failures as a clean `formError` message

## Test plan

- [ ] Deploy to prod server and visit `/admin/data` — confirm the new section appears
- [ ] Click **Sync Test Database from Production** — confirm it completes and shows the success message
- [ ] Connect to `flexspotff_test` and spot-check row counts against prod
- [ ] Have a dev set `DATABASE_URL` to the test DB connection string (no Discord channel IDs set) and confirm login and data work correctly
- [ ] Run `npm run db:sync-prod-to-test` on the server CLI and confirm it exits cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)