### PR TITLE
fix: add missing D12 migration and CI schema-drift guardrail

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -99,6 +99,40 @@ jobs:
       - name: ⚡ Run vitest
         run: npm run test
 
+  migrations:
+    name: 🗃️ Migration drift
+    runs-on: ubuntu-latest
+    env:
+      DATABASE_URL: 'postgresql://postgres:postgres@localhost:5432/flexspotff_test'
+    steps:
+      - name: ⬇️ Checkout repo
+        uses: actions/checkout@v4
+
+      - name: ⎔ Setup node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: 'npm'
+
+      - name: 📥 Install deps
+        run: npm ci
+
+      - name: 🐳 Docker compose
+        # the sleep is just there to give time for postgres to get started
+        run: docker compose up -d && sleep 3
+
+      - name: 🚚 Apply committed migrations
+        run: npx prisma migrate deploy
+
+      - name: 🔍 Check schema matches migrations
+        # exits non-zero (2) if schema.prisma has changes not captured in a
+        # migration, i.e. a model was added without a matching migration file
+        run: >
+          npx prisma migrate diff
+          --from-url "$DATABASE_URL"
+          --to-schema-datamodel prisma/schema.prisma
+          --exit-code
+
   build:
     name: 🐳 Build
     # only build/deploy main branch on pushes
@@ -147,7 +181,7 @@ jobs:
   deploy:
     name: 🚀 Deploy
     runs-on: ubuntu-latest
-    needs: [lint, typecheck, format, vitest, build]
+    needs: [lint, typecheck, format, vitest, migrations, build]
     # only deploy main/dev branch on pushes
     if:
       ${{ (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/dev') &&

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -128,10 +128,8 @@ jobs:
         # exits non-zero (2) if schema.prisma has changes not captured in a
         # migration, i.e. a model was added without a matching migration file
         run: >
-          npx prisma migrate diff
-          --from-url "$DATABASE_URL"
-          --to-schema-datamodel prisma/schema.prisma
-          --exit-code
+          npx prisma migrate diff --from-url "$DATABASE_URL"
+          --to-schema-datamodel prisma/schema.prisma --exit-code
 
   build:
     name: 🐳 Build

--- a/prisma/migrations/20260708041859_add_d12_section/migration.sql
+++ b/prisma/migrations/20260708041859_add_d12_section/migration.sql
@@ -1,0 +1,84 @@
+-- CreateTable
+CREATE TABLE "D12Season" (
+    "id" TEXT NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+    "year" INTEGER NOT NULL,
+
+    CONSTRAINT "D12Season_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "D12League" (
+    "id" TEXT NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+    "name" TEXT NOT NULL,
+    "sleeperLeagueId" TEXT NOT NULL,
+    "d12SeasonId" TEXT NOT NULL,
+
+    CONSTRAINT "D12League_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "D12WeekScore" (
+    "id" TEXT NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+    "week" INTEGER NOT NULL,
+    "points" DOUBLE PRECISION,
+    "d12LeagueId" TEXT NOT NULL,
+    "userId" TEXT NOT NULL,
+
+    CONSTRAINT "D12WeekScore_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "D12DraftPick" (
+    "id" TEXT NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+    "sleeperId" TEXT NOT NULL,
+    "pickNo" INTEGER NOT NULL,
+    "d12LeagueId" TEXT NOT NULL,
+    "userId" TEXT,
+
+    CONSTRAINT "D12DraftPick_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "D12Season_year_key" ON "D12Season"("year");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "D12League_sleeperLeagueId_key" ON "D12League"("sleeperLeagueId");
+
+-- CreateIndex
+CREATE INDEX "D12League_d12SeasonId_idx" ON "D12League"("d12SeasonId");
+
+-- CreateIndex
+CREATE INDEX "D12WeekScore_d12LeagueId_week_idx" ON "D12WeekScore"("d12LeagueId", "week");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "D12WeekScore_d12LeagueId_userId_week_key" ON "D12WeekScore"("d12LeagueId", "userId", "week");
+
+-- CreateIndex
+CREATE INDEX "D12DraftPick_d12LeagueId_idx" ON "D12DraftPick"("d12LeagueId");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "D12DraftPick_d12LeagueId_sleeperId_key" ON "D12DraftPick"("d12LeagueId", "sleeperId");
+
+-- AddForeignKey
+ALTER TABLE "D12League" ADD CONSTRAINT "D12League_d12SeasonId_fkey" FOREIGN KEY ("d12SeasonId") REFERENCES "D12Season"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "D12WeekScore" ADD CONSTRAINT "D12WeekScore_d12LeagueId_fkey" FOREIGN KEY ("d12LeagueId") REFERENCES "D12League"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "D12WeekScore" ADD CONSTRAINT "D12WeekScore_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "D12DraftPick" ADD CONSTRAINT "D12DraftPick_d12LeagueId_fkey" FOREIGN KEY ("d12LeagueId") REFERENCES "D12League"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "D12DraftPick" ADD CONSTRAINT "D12DraftPick_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+


### PR DESCRIPTION
## Problem

Production `/games` returns HTTP 500:

```
PrismaClientKnownRequestError P2021: The table `public.D12Season` does not exist in the current database.
```

PR #131 (D12 feature) added the `D12Season`, `D12League`, `D12WeekScore`, and `D12DraftPick` models to `prisma/schema.prisma` but **shipped no migration**. Production applies schema changes only via `prisma migrate deploy` (in `start:production`), which replays committed migration files and never runs `db push` — so these tables were never created in prod.

## Changes

1. **Add the missing migration** (`add_d12_section`), generated by diffing committed migrations against the schema. It only creates the four D12 tables plus their indexes/FKs — nothing destructive. Verified it applies cleanly to a fresh DB with `prisma migrate diff` reporting "No difference detected" afterward.

2. **Add a CI schema-drift guardrail** — a new `migrations` job that stands up Postgres, runs `prisma migrate deploy`, then `prisma migrate diff --from-url … --to-schema-datamodel … --exit-code` (exits non-zero when the schema has changes not captured in a migration). Wired into the `deploy` job's `needs`, so a drifted schema now blocks both deploys and PRs.

> Note: this is a separate job (not folded into `vitest`) on purpose — the `vitest` job seeds its DB via `prisma db push`, so a drift check there would always pass falsely. The guardrail must use `migrate deploy`.

## Deploy impact

No manual production intervention needed. On merge to `main`, the deploy's `prisma migrate deploy` will create the D12 tables and `/games` will recover.

## Verification

- New migration + all prior migrations apply cleanly on a fresh Postgres → drift check exits 0.
- Injected an uncommitted schema change → drift check exits 2 (fails CI); reverted clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)