### PR TITLE
Fix season year bug; add leagues column and guarded delete to /admin/season

### DIFF
--- a/app/models/league.server.ts
+++ b/app/models/league.server.ts
@@ -89,6 +89,14 @@ export async function getLeagueCountsByYear() {
   });
 }
 
+export async function getLeagueCountForYear(year: League['year']) {
+  return prisma.league.count({
+    where: {
+      year,
+    },
+  });
+}
+
 export async function updateLeague(league: Partial<League>) {
   return prisma.league.update({
     where: {

--- a/app/models/league.server.ts
+++ b/app/models/league.server.ts
@@ -82,6 +82,13 @@ export async function getLeaguesByYear(year: League['year']) {
   });
 }
 
+export async function getLeagueCountsByYear() {
+  return prisma.league.groupBy({
+    by: ['year'],
+    _count: { _all: true },
+  });
+}
+
 export async function updateLeague(league: Partial<League>) {
   return prisma.league.update({
     where: {

--- a/app/models/season.server.ts
+++ b/app/models/season.server.ts
@@ -54,6 +54,14 @@ export async function updateSeason(season: Partial<Season>) {
   });
 }
 
+export async function deleteSeason(id: Season['id']) {
+  return prisma.season.delete({
+    where: {
+      id,
+    },
+  });
+}
+
 export async function updateActiveSeason(id: Season['id']) {
   return prisma.$transaction([
     prisma.season.updateMany({

--- a/app/routes/admin.season._index.tsx
+++ b/app/routes/admin.season._index.tsx
@@ -30,8 +30,7 @@ export const action = async ({ request }: ActionFunctionArgs) => {
 
   switch (action) {
     case 'createSeason': {
-      //const year = new Date().getFullYear();
-      const year = new Date('2024-04-01').getFullYear();
+      const year = new Date().getFullYear();
       const season = await createSeason({
         year,
         isCurrent: false,

--- a/app/routes/admin.season._index.tsx
+++ b/app/routes/admin.season._index.tsx
@@ -7,7 +7,10 @@ import {
 } from 'remix-typedjson';
 import Alert from '~/components/ui/Alert';
 import Button from '~/components/ui/FlexSpotButton';
-import { getLeagueCountsByYear, getLeaguesByYear } from '~/models/league.server';
+import {
+  getLeagueCountForYear,
+  getLeagueCountsByYear,
+} from '~/models/league.server';
 import {
   createSeason,
   deleteSeason,
@@ -58,8 +61,14 @@ export const action = async ({ request }: ActionFunctionArgs) => {
         return typedjson({ message: 'Season not found.' });
       }
 
-      const leagues = await getLeaguesByYear(season.year);
-      if (leagues.length > 0) {
+      if (season.isCurrent) {
+        return typedjson({
+          message: `Cannot delete the active season.`,
+        });
+      }
+
+      const leagueCount = await getLeagueCountForYear(season.year);
+      if (leagueCount > 0) {
         return typedjson({
           message: `Cannot delete a season that has leagues attached.`,
         });
@@ -209,7 +218,7 @@ export default function SeasonIndex() {
                       </Button>
                     </Form>
                   )}
-                  {leagueCount === 0 && (
+                  {!isCurrent && leagueCount === 0 && (
                     <Form method='POST' style={{ display: 'inline' }}>
                       <input type='hidden' name='seasonId' value={id} />
                       <Button

--- a/app/routes/admin.season._index.tsx
+++ b/app/routes/admin.season._index.tsx
@@ -7,8 +7,11 @@ import {
 } from 'remix-typedjson';
 import Alert from '~/components/ui/Alert';
 import Button from '~/components/ui/FlexSpotButton';
+import { getLeagueCountsByYear, getLeaguesByYear } from '~/models/league.server';
 import {
   createSeason,
+  deleteSeason,
+  getSeasonById,
   getSeasons,
   updateActiveSeason,
   updateSeason,
@@ -42,6 +45,30 @@ export const action = async ({ request }: ActionFunctionArgs) => {
 
       return typedjson({
         message: `${season.year} season has been created`,
+      });
+    }
+    case 'deleteSeason': {
+      const seasonId = formData.get('seasonId');
+      if (typeof seasonId !== 'string') {
+        throw new Error(`Form not generated correctly.`);
+      }
+
+      const season = await getSeasonById(seasonId);
+      if (!season) {
+        return typedjson({ message: 'Season not found.' });
+      }
+
+      const leagues = await getLeaguesByYear(season.year);
+      if (leagues.length > 0) {
+        return typedjson({
+          message: `Cannot delete a season that has leagues attached.`,
+        });
+      }
+
+      await deleteSeason(seasonId);
+
+      return typedjson({
+        message: `${season.year} season has been deleted`,
       });
     }
     case 'setActive': {
@@ -122,11 +149,17 @@ export const loader = async ({ request }: LoaderFunctionArgs) => {
 
   const seasons = await getSeasons();
 
-  return typedjson({ seasons });
+  const leagueCounts = await getLeagueCountsByYear();
+  const leagueCountsByYear: Record<number, number> = {};
+  for (const { year, _count } of leagueCounts) {
+    leagueCountsByYear[year] = _count._all;
+  }
+
+  return typedjson({ seasons, leagueCountsByYear });
 };
 
 export default function SeasonIndex() {
-  const { seasons } = useTypedLoaderData<typeof loader>();
+  const { seasons, leagueCountsByYear } = useTypedLoaderData<typeof loader>();
   const actionData = useTypedActionData<typeof action>();
   const navigation = useNavigation();
 
@@ -138,6 +171,7 @@ export default function SeasonIndex() {
         <thead>
           <tr>
             <th>Year</th>
+            <th>Leagues</th>
             <th>Active?</th>
             <th>Open Registration?</th>
             <th>Open F²?</th>
@@ -156,9 +190,12 @@ export default function SeasonIndex() {
               isOpenForDFSSurvivor,
             } = season;
 
+            const leagueCount = leagueCountsByYear[year] ?? 0;
+
             return (
               <tr key={id}>
                 <td>{year}</td>
+                <td>{leagueCount}</td>
                 <td>{isCurrent ? 'Yes' : 'No'}</td>
                 <td>{isOpenForRegistration ? 'Yes' : 'No'}</td>
                 <td>{isOpenForFSquared ? 'Yes' : 'No'}</td>
@@ -169,6 +206,27 @@ export default function SeasonIndex() {
                       <input type='hidden' name='seasonId' value={id} />
                       <Button type='submit' name='_action' value='setActive'>
                         Set Active
+                      </Button>
+                    </Form>
+                  )}
+                  {leagueCount === 0 && (
+                    <Form method='POST' style={{ display: 'inline' }}>
+                      <input type='hidden' name='seasonId' value={id} />
+                      <Button
+                        type='submit'
+                        name='_action'
+                        value='deleteSeason'
+                        onClick={e => {
+                          if (
+                            !confirm(
+                              'Are you sure you want to delete this season?',
+                            )
+                          ) {
+                            e.preventDefault();
+                          }
+                        }}
+                      >
+                        Delete
                       </Button>
                     </Form>
                   )}


### PR DESCRIPTION
## Summary

Fixes the season-creation year bug on `/admin/season` and adds two admin conveniences: a leagues-attached count column and a guarded delete button.

## Changes

**1. Fix "Create Season" always making a 2024 season**
The `createSeason` action had leftover debug code (`new Date('2024-04-01')`) with the real line commented out, so every new season came out as 2024 despite the button reading "Create Season for Current Year". Restored `new Date().getFullYear()`.

**2. "Leagues" column**
Added a column showing how many leagues are attached to each season. `League` and `Season` aren't FK-related — they're linked by matching `year` — so counts come from a single `groupBy` (`getLeagueCountsByYear`) mapped to `year → count`.

**3. Guarded Delete button**
Added a `deleteSeason` action + button (with a confirm dialog, matching the existing `DraftSlotRow` pattern). Deletion is only allowed for a season that is **not active** and has **0 leagues attached**; the server action enforces both guards and the button is hidden otherwise. `SeasonWeek` rows cascade automatically; leagues are untouched.

## Review follow-ups (addressed)
- Delete guard uses a lightweight `prisma.league.count` (`getLeagueCountForYear`) instead of fetching every league with its teams/users just to check existence.
- Blocked deleting the active season, which would otherwise leave `getCurrentSeason()` returning null and break admin pages that depend on it.

## Verification
- `npx tsc --noEmit` clean for the touched files.
- Manual: creating a season now yields the current year (2026); the Leagues column reflects per-year league counts; delete works for empty non-active seasons and is rejected (button hidden + server guard) for active seasons or seasons with leagues.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01QcPeaeJKyjcgMCS5RDcERk)_