### PR TITLE
Refactor draft preferences to use season IDs and simplify registration

### DIFF
--- a/app/components/layout/admin/DraftSlotRow.tsx
+++ b/app/components/layout/admin/DraftSlotRow.tsx
@@ -10,7 +10,7 @@ type User = {
 
 type DraftSlot = {
   id: string;
-  season: number;
+  season: { year: number };
   draftDateTime: Date;
   availableCount: number;
   availableUsers: User[];
@@ -30,7 +30,7 @@ export default function DraftSlotRow({ slot }: Props) {
   return (
     <>
       <tr>
-        <td>{slot.season}</td>
+        <td>{slot.season.year}</td>
         <td className='flex items-center gap-3'>
           {new Date(slot.draftDateTime).toLocaleString(undefined, {
             year: 'numeric',

--- a/app/models/draftSlot.server.ts
+++ b/app/models/draftSlot.server.ts
@@ -5,13 +5,25 @@ export type { DraftSlot } from '@prisma/client';
 
 export function getDraftSlots() {
   return prisma.draftSlot.findMany({
-    orderBy: [{ season: 'desc' }, { draftDateTime: 'asc' }],
+    include: {
+      season: {
+        select: {
+          year: true,
+        },
+      },
+    },
+    orderBy: [{ season: { year: 'desc' } }, { draftDateTime: 'asc' }],
   });
 }
 
 export async function getDraftSlotsWithPreferenceCounts() {
   const draftSlots = await prisma.draftSlot.findMany({
     include: {
+      season: {
+        select: {
+          year: true,
+        },
+      },
       preferences: {
         include: {
           user: {
@@ -23,7 +35,7 @@ export async function getDraftSlotsWithPreferenceCounts() {
         },
       },
     },
-    orderBy: [{ season: 'desc' }, { draftDateTime: 'asc' }],
+    orderBy: [{ season: { year: 'desc' } }, { draftDateTime: 'asc' }],
   });
 
   return draftSlots.map(slot => ({
@@ -52,12 +64,12 @@ export function getDraftSlot({ id }: Pick<DraftSlot, 'id'>) {
 
 export function createDraftSlot({
   draftDateTime,
-  season,
-}: Pick<DraftSlot, 'draftDateTime' | 'season'>) {
+  seasonId,
+}: Pick<DraftSlot, 'draftDateTime' | 'seasonId'>) {
   return prisma.draftSlot.create({
     data: {
       draftDateTime,
-      season,
+      seasonId,
     },
   });
 }
@@ -65,13 +77,13 @@ export function createDraftSlot({
 export function updateDraftSlot({
   id,
   draftDateTime,
-  season,
-}: Pick<DraftSlot, 'id' | 'draftDateTime' | 'season'>) {
+  seasonId,
+}: Pick<DraftSlot, 'id' | 'draftDateTime' | 'seasonId'>) {
   return prisma.draftSlot.update({
     where: { id },
     data: {
       draftDateTime,
-      season,
+      seasonId,
     },
   });
 }
@@ -82,9 +94,9 @@ export function deleteDraftSlot({ id }: Pick<DraftSlot, 'id'>) {
   });
 }
 
-export function getDraftSlotsBySeason({ season }: { season: number }) {
+export function getDraftSlotsBySeason({ seasonId }: { seasonId: string }) {
   return prisma.draftSlot.findMany({
-    where: { season },
+    where: { seasonId },
     orderBy: { draftDateTime: 'asc' },
   });
 }

--- a/app/models/draftSlotPreference.server.ts
+++ b/app/models/draftSlotPreference.server.ts
@@ -40,24 +40,23 @@ export async function upsertUserDraftSlotPreferences(
   seasonId: string,
   draftSlotIds: string[],
 ): Promise<void> {
-  // Delete existing preferences for this user and season
-  await prisma.draftSlotPreference.deleteMany({
-    where: {
-      userId,
-      seasonId,
-    },
-  });
-
-  // Create new preferences
-  if (draftSlotIds.length > 0) {
-    await prisma.draftSlotPreference.createMany({
+  // Replace the user's preferences for this season atomically so a failed
+  // insert can't leave them with no preferences.
+  await prisma.$transaction([
+    prisma.draftSlotPreference.deleteMany({
+      where: {
+        userId,
+        seasonId,
+      },
+    }),
+    prisma.draftSlotPreference.createMany({
       data: draftSlotIds.map(draftSlotId => ({
         userId,
         draftSlotId,
         seasonId,
       })),
-    });
-  }
+    }),
+  ]);
 }
 
 export async function getDraftSlotsWithUserPreferences(
@@ -83,8 +82,8 @@ export async function getDraftSlotsWithUserPreferences(
     },
   });
 
-  return draftSlots.map(slot => ({
+  return draftSlots.map(({ preferences, ...slot }) => ({
     ...slot,
-    isSelected: slot.preferences.length > 0,
+    isSelected: preferences.length > 0,
   }));
 }

--- a/app/models/draftSlotPreference.server.ts
+++ b/app/models/draftSlotPreference.server.ts
@@ -7,55 +7,54 @@ export type DraftSlotPreferenceWithDraftSlot = DraftSlotPreference & {
   draftSlot: {
     id: string;
     draftDateTime: Date;
-    season: number;
   };
 };
 
 export async function getUserDraftSlotPreferences(
   userId: string,
-  season: number,
+  seasonId: string,
 ): Promise<DraftSlotPreferenceWithDraftSlot[]> {
   return prisma.draftSlotPreference.findMany({
     where: {
       userId,
-      season,
+      seasonId,
     },
     include: {
       draftSlot: {
         select: {
           id: true,
           draftDateTime: true,
-          season: true,
         },
       },
     },
     orderBy: {
-      ranking: 'asc',
+      draftSlot: {
+        draftDateTime: 'asc',
+      },
     },
   });
 }
 
 export async function upsertUserDraftSlotPreferences(
   userId: string,
-  season: number,
-  preferences: { draftSlotId: string; ranking: number }[],
+  seasonId: string,
+  draftSlotIds: string[],
 ): Promise<void> {
   // Delete existing preferences for this user and season
   await prisma.draftSlotPreference.deleteMany({
     where: {
       userId,
-      season,
+      seasonId,
     },
   });
 
   // Create new preferences
-  if (preferences.length > 0) {
+  if (draftSlotIds.length > 0) {
     await prisma.draftSlotPreference.createMany({
-      data: preferences.map(pref => ({
+      data: draftSlotIds.map(draftSlotId => ({
         userId,
-        draftSlotId: pref.draftSlotId,
-        season,
-        ranking: pref.ranking,
+        draftSlotId,
+        seasonId,
       })),
     });
   }
@@ -63,11 +62,11 @@ export async function upsertUserDraftSlotPreferences(
 
 export async function getDraftSlotsWithUserPreferences(
   userId: string,
-  season: number,
+  seasonId: string,
 ) {
   const draftSlots = await prisma.draftSlot.findMany({
     where: {
-      season,
+      seasonId,
     },
     include: {
       preferences: {
@@ -75,7 +74,7 @@ export async function getDraftSlotsWithUserPreferences(
           userId,
         },
         select: {
-          ranking: true,
+          id: true,
         },
       },
     },
@@ -86,6 +85,6 @@ export async function getDraftSlotsWithUserPreferences(
 
   return draftSlots.map(slot => ({
     ...slot,
-    userRanking: slot.preferences[0]?.ranking || null,
+    isSelected: slot.preferences.length > 0,
   }));
 }

--- a/app/models/registration.server.ts
+++ b/app/models/registration.server.ts
@@ -67,6 +67,12 @@ export async function getRegistrationByUserAndYear(
   });
 }
 
+export async function getRegistrationCountByYear(year: Registration['year']) {
+  return prisma.registration.count({
+    where: { year },
+  });
+}
+
 export async function getRegistrationsByYear(year: Registration['year']) {
   return prisma.registration.findMany({
     where: { year },

--- a/app/models/registration.server.ts
+++ b/app/models/registration.server.ts
@@ -19,6 +19,45 @@ export async function createRegistration(
   });
 }
 
+/**
+ * Atomically register a user for a season and save their draft-time
+ * preferences. Used for the combined "register + pick at least 3 times" flow.
+ */
+export async function registerWithDraftPreferences(
+  userId: User['id'],
+  year: Registration['year'],
+  seasonId: string,
+  draftSlotIds: string[],
+) {
+  const [registration] = await prisma.$transaction([
+    prisma.registration.create({
+      data: {
+        year,
+        user: {
+          connect: {
+            id: userId,
+          },
+        },
+      },
+    }),
+    prisma.draftSlotPreference.deleteMany({
+      where: {
+        userId,
+        seasonId,
+      },
+    }),
+    prisma.draftSlotPreference.createMany({
+      data: draftSlotIds.map(draftSlotId => ({
+        userId,
+        draftSlotId,
+        seasonId,
+      })),
+    }),
+  ]);
+
+  return registration;
+}
+
 export async function getRegistrationByUserAndYear(
   userId: User['id'],
   year: Registration['year'],

--- a/app/routes/admin.draft-slots.$id.edit.tsx
+++ b/app/routes/admin.draft-slots.$id.edit.tsx
@@ -16,7 +16,7 @@ import { isSuccessWithMessage, isErrorResponse } from '~/utils/types';
 
 const draftSlotSchema = z.object({
   draftDateTime: z.string().min(1, 'Draft date and time is required'),
-  season: z.string().min(1, 'Season is required').transform(Number),
+  seasonId: z.string().min(1, 'Season is required'),
 });
 
 export const action = async ({ request, params }: ActionFunctionArgs) => {
@@ -40,13 +40,13 @@ export const action = async ({ request, params }: ActionFunctionArgs) => {
     );
   }
 
-  const { draftDateTime, season } = submission.data;
+  const { draftDateTime, seasonId } = submission.data;
 
   try {
     await updateDraftSlot({
       id,
       draftDateTime: new Date(draftDateTime),
-      season,
+      seasonId,
     });
     return typedjson({
       success: true,
@@ -123,28 +123,28 @@ export default function EditDraftSlot() {
       )}
       <Form method='post' className='grid grid-cols-1 gap-6'>
         <div>
-          <label htmlFor='season'>
+          <label htmlFor='seasonId'>
             Season:
             <select
-              name='season'
-              id='season'
+              name='seasonId'
+              id='seasonId'
               className='mt-1 block w-full dark:border-0 dark:bg-slate-800'
               required
-              defaultValue={draftSlot.season}
+              defaultValue={draftSlot.seasonId}
             >
               <option value=''>Select a season...</option>
               {seasons.map((season: any) => (
-                <option key={season.id} value={season.year}>
+                <option key={season.id} value={season.id}>
                   {season.year} {season.isCurrent ? '(Current)' : ''}
                 </option>
               ))}
             </select>
           </label>
           {isErrorResponse(actionData) &&
-            'season' in actionData.error &&
-            actionData.error.season && (
+            'seasonId' in actionData.error &&
+            actionData.error.seasonId && (
               <p className='form-validation-error' role='alert'>
-                {actionData.error.season[0]}
+                {actionData.error.seasonId[0]}
               </p>
             )}
         </div>

--- a/app/routes/admin.draft-slots._index.tsx
+++ b/app/routes/admin.draft-slots._index.tsx
@@ -21,8 +21,8 @@ import { isSuccessWithMessage, isErrorResponse } from '~/utils/types';
 
 const draftSlotSchema = z.object({
   id: z.string().optional(),
-  draftDateTime: z.string().min(1, 'Draft date and time is required'),
-  season: z.string().min(1, 'Season is required').transform(Number),
+  draftDateTime: z.string().optional(),
+  seasonId: z.string().optional(),
   action: z.enum(['create', 'update', 'delete']),
 });
 
@@ -42,14 +42,25 @@ export const action = async ({ request }: ActionFunctionArgs) => {
     );
   }
 
-  const { id, draftDateTime, season, action } = submission.data;
+  const { id, draftDateTime, seasonId, action } = submission.data;
 
   try {
     switch (action) {
       case 'create':
+        if (!draftDateTime || !seasonId) {
+          return typedjson(
+            {
+              success: false,
+              error: {
+                general: ['Draft date/time and season are required'],
+              },
+            },
+            { status: 400 },
+          );
+        }
         await createDraftSlot({
           draftDateTime: new Date(draftDateTime),
-          season,
+          seasonId,
         });
         return typedjson({
           success: true,
@@ -66,10 +77,21 @@ export const action = async ({ request }: ActionFunctionArgs) => {
             { status: 400 },
           );
         }
+        if (!draftDateTime || !seasonId) {
+          return typedjson(
+            {
+              success: false,
+              error: {
+                general: ['Draft date/time and season are required'],
+              },
+            },
+            { status: 400 },
+          );
+        }
         await updateDraftSlot({
           id,
           draftDateTime: new Date(draftDateTime),
-          season,
+          seasonId,
         });
         return typedjson({
           success: true,

--- a/app/routes/admin.draft-slots.new.tsx
+++ b/app/routes/admin.draft-slots.new.tsx
@@ -16,10 +16,7 @@ import { isSuccessWithMessage, isErrorResponse } from '~/utils/types';
 
 const draftSlotSchema = z.object({
   draftDateTime: z.string().min(1, 'Draft date and time is required'),
-  season: z
-    .string()
-    .min(1, 'Season is required')
-    .transform(val => parseInt(val, 10)),
+  seasonId: z.string().min(1, 'Season is required'),
 });
 
 export const action = async ({ request }: ActionFunctionArgs) => {
@@ -38,12 +35,12 @@ export const action = async ({ request }: ActionFunctionArgs) => {
     );
   }
 
-  const { draftDateTime, season } = submission.data;
+  const { draftDateTime, seasonId } = submission.data;
 
   try {
     await createDraftSlot({
       draftDateTime: new Date(draftDateTime),
-      season,
+      seasonId,
     });
     return typedjson({
       success: true,
@@ -102,32 +99,32 @@ export default function NewDraftSlot() {
       )}
       <Form ref={formRef} method='post' className='grid grid-cols-1 gap-6'>
         <div>
-          <label htmlFor='season'>
+          <label htmlFor='seasonId'>
             Season:
             <select
-              name='season'
-              id='season'
+              name='seasonId'
+              id='seasonId'
               className='mt-1 block w-full dark:border-0 dark:bg-slate-800'
               required
               defaultValue={
-                seasons.find((s: any) => s.isCurrent)?.year ||
-                seasons[0]?.year ||
+                seasons.find((s: any) => s.isCurrent)?.id ||
+                seasons[0]?.id ||
                 ''
               }
             >
               <option value=''>Select a season...</option>
               {seasons.map((season: any) => (
-                <option key={season.id} value={season.year}>
+                <option key={season.id} value={season.id}>
                   {season.year} {season.isCurrent ? '(Current)' : ''}
                 </option>
               ))}
             </select>
           </label>
           {isErrorResponse(actionData) &&
-            'season' in actionData.error &&
-            actionData.error.season && (
+            'seasonId' in actionData.error &&
+            actionData.error.seasonId && (
               <p className='form-validation-error' role='alert'>
-                {actionData.error.season[0]}
+                {actionData.error.seasonId[0]}
               </p>
             )}
         </div>

--- a/app/routes/admin.season.$id.sorting.tsx
+++ b/app/routes/admin.season.$id.sorting.tsx
@@ -117,7 +117,6 @@ interface SortingResultData {
 interface PlayerPreferences {
   [playerId: string]: Array<{
     draftSlotId: string;
-    ranking: number;
     draftDateTime?: Date;
   }>;
 }
@@ -284,7 +283,7 @@ export const action = async ({ request, params }: ActionFunctionArgs) => {
     sortedLeagueNames.forEach(leagueName => {
       const groups = leagueGroups[leagueName];
       const embed = new EmbedBuilder()
-        .setTitle(`🏈 ${leagueName} League 2025`)
+        .setTitle(`🏈 ${leagueName} League ${season.year}`)
         .setColor(leagueColors[leagueName.toLowerCase()] || 0x00ff00);
 
       groups.forEach((group: AnnouncementGroup) => {
@@ -374,7 +373,6 @@ export const action = async ({ request, params }: ActionFunctionArgs) => {
             Array<{
               draftSlotId: string;
               draftDateTime: Date;
-              ranking: number;
             }>
           >, // Keep empty for now
         });
@@ -428,7 +426,6 @@ export const action = async ({ request, params }: ActionFunctionArgs) => {
             Array<{
               draftSlotId: string;
               draftDateTime: Date;
-              ranking: number;
             }>
           >, // Keep empty for now
         });
@@ -472,7 +469,6 @@ export const action = async ({ request, params }: ActionFunctionArgs) => {
           Array<{
             draftSlotId: string;
             draftDateTime: Date;
-            ranking: number;
           }>
         >, // Keep empty for now
       });
@@ -499,8 +495,17 @@ export const action = async ({ request, params }: ActionFunctionArgs) => {
     }
 
     try {
-      // Get draft slots for this season
-      const draftSlots = await getDraftSlotsBySeason({ season: season.year });
+      // Get draft slots for this season. Attach the season year so downstream
+      // grouping/announcement code can keep displaying it (all slots here
+      // belong to the same season).
+      const seasonDraftSlots = await getDraftSlotsBySeason({
+        seasonId: season.id,
+      });
+      const draftSlots = seasonDraftSlots.map(slot => ({
+        id: slot.id,
+        draftDateTime: slot.draftDateTime,
+        season: season.year,
+      }));
 
       if (draftSlots.length === 0) {
         return typedjson({
@@ -526,33 +531,19 @@ export const action = async ({ request, params }: ActionFunctionArgs) => {
       for (const player of selectedPlayerData) {
         const preferences = await getUserDraftSlotPreferences(
           player.id,
-          season.year,
+          season.id,
         );
 
         if (preferences.length > 0) {
-          // Separate ranked vs unranked preferences
-          const rankedPreferences = preferences.filter(p => p.ranking > 0);
-
-          if (rankedPreferences.length > 0) {
-            // Player has ranked preferences
-            playersWithPreferences.push({
-              id: player.id,
-              discordName: player.discordName,
-              discordId: player.discordId,
-              preferences: rankedPreferences.map(p => ({
-                draftSlotId: p.draftSlotId,
-                ranking: p.ranking,
-              })),
-            });
-          } else {
-            // Player has availability but no rankings - treat as available for all their slots
-            playersWithoutPreferences.push({
-              id: player.id,
-              discordName: player.discordName,
-              discordId: player.discordId,
-              allAvailableSlots: preferences.map(p => p.draftSlotId),
-            });
-          }
+          // Player has selected the times they are available for
+          playersWithPreferences.push({
+            id: player.id,
+            discordName: player.discordName,
+            discordId: player.discordId,
+            preferences: preferences.map(p => ({
+              draftSlotId: p.draftSlotId,
+            })),
+          });
         } else {
           // Player has no preferences recorded - assume they're available for all slots
           playersWithoutPreferences.push({
@@ -580,20 +571,18 @@ export const action = async ({ request, params }: ActionFunctionArgs) => {
         Array<{
           draftSlotId: string;
           draftDateTime: Date;
-          ranking: number;
         }>
       > = {};
 
       for (const player of selectedPlayerData) {
         const preferences = await getUserDraftSlotPreferences(
           player.id,
-          season.year,
+          season.id,
         );
         if (preferences.length > 0) {
           playerPreferencesMap[player.id] = preferences.map(p => ({
             draftSlotId: p.draftSlotId,
             draftDateTime: p.draftSlot.draftDateTime,
-            ranking: p.ranking,
           }));
         }
       }
@@ -647,7 +636,7 @@ function trySlotCombination(
     discordId: string;
     availableSlots: string[];
     hasPreferences: boolean;
-    preferences: Array<{ draftSlotId: string; ranking: number }>;
+    preferences: Array<{ draftSlotId: string }>;
   }>,
   slotCombo: Array<{
     id: string;
@@ -675,12 +664,7 @@ function trySlotCombination(
   for (const player of shuffledPlayers.filter(p => p.hasPreferences)) {
     let assigned = false;
 
-    // Sort player's preferences by ranking (1 is highest preference)
-    const sortedPreferences = [...player.preferences].sort(
-      (a, b) => a.ranking - b.ranking,
-    );
-
-    for (const pref of sortedPreferences) {
+    for (const pref of player.preferences) {
       if (!slotCombo.some(slot => slot.id === pref.draftSlotId)) continue; // Skip if slot not in this combination
 
       const currentAssignment = slotAssignments.get(pref.draftSlotId);
@@ -799,10 +783,10 @@ function trySlotCombination(
       originalPlayer.hasPreferences &&
       originalPlayer.preferences.length > 0
     ) {
-      // Use their top preference from the combination
-      const topPref = originalPlayer.preferences
-        .filter(pref => slotCombo.some(slot => slot.id === pref.draftSlotId))
-        .sort((a, b) => a.ranking - b.ranking)[0];
+      // Use their first available preference from the combination
+      const topPref = originalPlayer.preferences.filter(pref =>
+        slotCombo.some(slot => slot.id === pref.draftSlotId),
+      )[0];
       if (topPref) {
         bestSlot = slotCombo.find(slot => slot.id === topPref.draftSlotId);
       }
@@ -874,7 +858,7 @@ function calculateCombinationScore(
     discordId: string;
     availableSlots: string[];
     hasPreferences: boolean;
-    preferences: Array<{ draftSlotId: string; ranking: number }>;
+    preferences: Array<{ draftSlotId: string }>;
   }>,
 ): number {
   // Primary score: number of completed groups (most important)
@@ -899,7 +883,7 @@ function sortPlayersIntoDraftSlots(
     id: string;
     discordName: string;
     discordId: string;
-    preferences: Array<{ draftSlotId: string; ranking: number }>;
+    preferences: Array<{ draftSlotId: string }>;
   }>,
   playersWithoutPreferences: Array<{
     id: string;

--- a/app/routes/admin.season._index.tsx
+++ b/app/routes/admin.season._index.tsx
@@ -14,6 +14,7 @@ import {
 import {
   createSeason,
   deleteSeason,
+  getSeason,
   getSeasonById,
   getSeasons,
   updateActiveSeason,
@@ -37,6 +38,14 @@ export const action = async ({ request }: ActionFunctionArgs) => {
   switch (action) {
     case 'createSeason': {
       const year = new Date().getFullYear();
+
+      const existingSeason = await getSeason(year);
+      if (existingSeason) {
+        return typedjson({
+          message: `A ${year} season already exists.`,
+        });
+      }
+
       const season = await createSeason({
         year,
         isCurrent: false,

--- a/app/routes/dashboard.tsx
+++ b/app/routes/dashboard.tsx
@@ -1,5 +1,6 @@
 import type { ActionFunctionArgs, LoaderFunctionArgs } from '@remix-run/node';
-import { Form } from '@remix-run/react';
+import { Form, useNavigation } from '@remix-run/react';
+import clsx from 'clsx';
 import { useState } from 'react';
 import {
   typedjson,
@@ -8,18 +9,21 @@ import {
 } from 'remix-typedjson';
 import Alert from '~/components/ui/Alert';
 import Button from '~/components/ui/FlexSpotButton';
+import { getDraftSlotsBySeason } from '~/models/draftSlot.server';
 import {
   getDraftSlotsWithUserPreferences,
   upsertUserDraftSlotPreferences,
 } from '~/models/draftSlotPreference.server';
 import type { Registration } from '~/models/registration.server';
 import {
-  createRegistration,
   getRegistrationByUserAndYear,
   getRegistrationsByYear,
+  registerWithDraftPreferences,
 } from '~/models/registration.server';
 import { getCurrentSeason } from '~/models/season.server';
 import { authenticator } from '~/services/auth.server';
+
+const MINIMUM_DRAFT_TIMES = 3;
 
 type ActionData = {
   formError?: string;
@@ -27,57 +31,103 @@ type ActionData = {
   success?: boolean;
 };
 
+/**
+ * Parse the JSON list of selected draft-slot ids submitted by the form and
+ * narrow it to ids that actually belong to the given season.
+ */
+function parseSelectedSlotIds(
+  raw: FormDataEntryValue | null,
+  validSlotIds: Set<string>,
+): string[] | null {
+  if (typeof raw !== 'string') return null;
+  try {
+    const parsed = JSON.parse(raw);
+    if (!Array.isArray(parsed)) return null;
+    return parsed.filter(
+      (id): id is string => typeof id === 'string' && validSlotIds.has(id),
+    );
+  } catch {
+    return null;
+  }
+}
+
 export const action = async ({
   request,
 }: ActionFunctionArgs): Promise<Response | ActionData> => {
-  let user = await authenticator.isAuthenticated(request, {
+  const user = await authenticator.isAuthenticated(request, {
     failureRedirect: '/login',
   });
+
+  const currentSeason = await getCurrentSeason();
+  if (!currentSeason) {
+    return { formError: 'No active season currently' };
+  }
 
   const form = await request.formData();
   const actionType = form.get('actionType');
 
-  if (actionType === 'register') {
-    const formYear = form.get('year');
+  // Draft slots that exist for the current season, used to validate the
+  // submitted selection and to know whether registration is even possible.
+  const seasonSlots = await getDraftSlotsBySeason({
+    seasonId: currentSeason.id,
+  });
+  const validSlotIds = new Set(seasonSlots.map(slot => slot.id));
 
-    if (typeof formYear !== 'string') {
-      return { formError: `Form not submitted correctly` };
+  if (actionType === 'register') {
+    if (!currentSeason.isOpenForRegistration) {
+      return { formError: 'Registration is not currently open.' };
     }
 
-    const year = Number.parseInt(formYear, 10);
-    let registration = await createRegistration(user.id, year);
-    return typedjson({ registration });
+    const existing = await getRegistrationByUserAndYear(
+      user.id,
+      currentSeason.year,
+    );
+    if (existing) {
+      return { formError: 'You are already registered for this season.' };
+    }
+
+    if (validSlotIds.size === 0) {
+      return {
+        formError:
+          'Registration is not open yet — draft times have not been posted.',
+      };
+    }
+
+    const draftSlotIds = parseSelectedSlotIds(
+      form.get('preferences'),
+      validSlotIds,
+    );
+    if (!draftSlotIds || draftSlotIds.length < MINIMUM_DRAFT_TIMES) {
+      return {
+        formError: `Please select at least ${MINIMUM_DRAFT_TIMES} draft times you can make.`,
+      };
+    }
+
+    await registerWithDraftPreferences(
+      user.id,
+      currentSeason.year,
+      currentSeason.id,
+      draftSlotIds,
+    );
+    return typedjson({ success: true });
   }
 
   if (actionType === 'updateDraftPreferences') {
-    const season = form.get('season');
-    const preferences = form.get('preferences');
-
-    if (typeof season !== 'string' || typeof preferences !== 'string') {
-      return { formError: 'Invalid form data' };
+    const draftSlotIds = parseSelectedSlotIds(
+      form.get('preferences'),
+      validSlotIds,
+    );
+    if (!draftSlotIds || draftSlotIds.length < MINIMUM_DRAFT_TIMES) {
+      return {
+        formError: `Please select at least ${MINIMUM_DRAFT_TIMES} draft times you can make.`,
+      };
     }
 
     try {
-      const parsedPreferences = JSON.parse(preferences);
-
-      // Validate that at least 3 draft times are selected
-      if (!Array.isArray(parsedPreferences) || parsedPreferences.length < 3) {
-        return {
-          formError: 'Please select at least 3 draft times you can make.',
-        };
-      }
-
-      // Convert availability selections to ranking format for backend compatibility
-      // Set all selected slots to ranking 1 since there's no preference order
-      const rankedPreferences = parsedPreferences.map(pref => ({
-        draftSlotId: pref.draftSlotId,
-        ranking: 1,
-      }));
-
       await upsertUserDraftSlotPreferences(
         user.id,
-        Number.parseInt(season, 10),
-        rankedPreferences,
+        currentSeason.id,
+        draftSlotIds,
       );
       return typedjson({ success: true });
     } catch {
@@ -89,38 +139,38 @@ export const action = async ({
 };
 
 export const loader = async ({ request }: LoaderFunctionArgs) => {
-  let user = await authenticator.isAuthenticated(request, {
+  const user = await authenticator.isAuthenticated(request, {
     failureRedirect: '/login',
   });
 
-  let currentSeason = await getCurrentSeason();
+  const currentSeason = await getCurrentSeason();
   if (!currentSeason) {
     throw new Error('No active season currently');
   }
 
-  let registration = await getRegistrationByUserAndYear(
+  const registration = await getRegistrationByUserAndYear(
     user.id,
-    currentSeason?.year,
+    currentSeason.year,
   );
 
-  let registrations = await getRegistrationsByYear(currentSeason.year);
+  const registrations = await getRegistrationsByYear(currentSeason.year);
   const registrationsCount = registrations.length;
 
-  // Get draft slots with user preferences if user is registered
-  let draftSlotsWithPreferences = null;
-  if (registration) {
-    draftSlotsWithPreferences = await getDraftSlotsWithUserPreferences(
-      user.id,
-      currentSeason.year,
-    );
-  }
+  // Draft slots for the current season, annotated with whether this user has
+  // already selected each one. Loaded whether or not the user is registered so
+  // the combined registration form can show them.
+  const draftSlots = await getDraftSlotsWithUserPreferences(
+    user.id,
+    currentSeason.id,
+  );
 
   return typedjson({
     user,
     registration,
     currentSeason,
     registrationsCount,
-    draftSlotsWithPreferences,
+    draftSlots,
+    hasDraftSlots: draftSlots.length > 0,
   });
 };
 
@@ -129,206 +179,182 @@ export default function Dashboard() {
     registration,
     currentSeason,
     registrationsCount,
-    draftSlotsWithPreferences,
+    draftSlots,
+    hasDraftSlots,
   } = useTypedLoaderData<typeof loader>();
-  const actionData = useTypedActionData<typeof action>();
+  const actionData = useTypedActionData<typeof action>() as ActionData | null;
+  const navigation = useNavigation();
 
   const [selectedSlots, setSelectedSlots] = useState(() => {
-    if (!draftSlotsWithPreferences) return new Set<string>();
     const selected = new Set<string>();
-    draftSlotsWithPreferences.forEach((slot: any) => {
-      if (slot.userRanking) {
+    draftSlots.forEach(slot => {
+      if (slot.isSelected) {
         selected.add(slot.id);
       }
     });
     return selected;
   });
 
-  // Check if at least 3 slots are selected
-  const hasMinimumSelections = selectedSlots.size >= 3;
-  const canSave = hasMinimumSelections;
+  const hasMinimumSelections = selectedSlots.size >= MINIMUM_DRAFT_TIMES;
+  const isSubmitting = navigation.state !== 'idle';
 
   const isRegistrationFull =
     currentSeason.registrationSize <= registrationsCount;
 
-  const buttonText = `${
-    isRegistrationFull ? 'Join wait list' : 'Register'
-  } for ${currentSeason.year} Leagues`;
+  const registerButtonText = isRegistrationFull
+    ? `Join wait list for ${currentSeason.year} Leagues`
+    : `Register for ${currentSeason.year} Leagues`;
+
+  const toggleSlot = (slotId: string, checked: boolean) => {
+    setSelectedSlots(prev => {
+      const next = new Set(prev);
+      if (checked) {
+        next.add(slotId);
+      } else {
+        next.delete(slotId);
+      }
+      return next;
+    });
+  };
+
+  const renderSlotGrid = () => (
+    <div className='not-prose my-4 grid gap-2'>
+      {draftSlots.map((slot, index) => (
+        <label
+          key={slot.id}
+          className={clsx(
+            index % 2 === 0 ? 'bg-gray-900' : 'bg-gray-800',
+            'flex cursor-pointer items-center gap-3 rounded p-2',
+          )}
+        >
+          <input
+            type='checkbox'
+            name='draftSlot'
+            value={slot.id}
+            checked={selectedSlots.has(slot.id)}
+            onChange={e => toggleSlot(slot.id, e.target.checked)}
+            className='h-4 w-4 cursor-pointer'
+          />
+          <span>
+            {slot.draftDateTime.toLocaleString(undefined, {
+              weekday: 'long',
+              year: 'numeric',
+              month: 'long',
+              day: 'numeric',
+              hour: 'numeric',
+              minute: '2-digit',
+              timeZoneName: 'short',
+            })}
+          </span>
+        </label>
+      ))}
+    </div>
+  );
+
+  const renderSelectionStatus = () =>
+    hasMinimumSelections ? (
+      <p className='text-sm text-green-400'>
+        ✓ {selectedSlots.size} draft time
+        {selectedSlots.size === 1 ? '' : 's'} selected
+      </p>
+    ) : (
+      <p className='text-sm text-red-400'>
+        ⚠️ Please select at least {MINIMUM_DRAFT_TIMES} draft times you can
+        make. Currently selected: {selectedSlots.size}
+      </p>
+    );
 
   return (
     <div>
       <h2>{currentSeason.year} League Registration</h2>
+
+      {actionData?.success && (
+        <Alert message='Draft preferences saved successfully!' />
+      )}
+      {actionData?.formError && (
+        <Alert message={actionData.formError} status='error' />
+      )}
+
       {registration ? (
         <>
           <p>
             Thanks! You signed up at {registration.createdAt.toLocaleString()}
           </p>
-          {draftSlotsWithPreferences &&
-            draftSlotsWithPreferences.length > 0 && (
-              <div style={{ marginTop: '2rem' }}>
-                <h3>Draft Time Preferences</h3>
-                <p>
-                  Select all draft times that you can make. You must select at
-                  least 3 options:
-                </p>
+          {hasDraftSlots && (
+            <div>
+              <h3>Draft Time Preferences</h3>
+              <p>
+                Select all draft times that you can make. You must keep at least{' '}
+                {MINIMUM_DRAFT_TIMES} selected:
+              </p>
 
-                {(actionData as ActionData)?.success && (
-                  <div style={{ marginBottom: '1rem' }}>
-                    <Alert message='Draft preferences saved successfully!' />
-                  </div>
-                )}
-                {(actionData as ActionData)?.formError && (
-                  <div style={{ marginBottom: '1rem' }}>
-                    <Alert
-                      message={
-                        (actionData as ActionData).formError ||
-                        'An error occurred'
-                      }
-                    />
-                  </div>
-                )}
+              <Form method='post'>
+                <input
+                  type='hidden'
+                  name='actionType'
+                  value='updateDraftPreferences'
+                />
+                <input
+                  type='hidden'
+                  name='preferences'
+                  value={JSON.stringify(Array.from(selectedSlots))}
+                />
 
-                <Form method='post'>
-                  <input
-                    type='hidden'
-                    name='actionType'
-                    value='updateDraftPreferences'
-                  />
-                  <input
-                    type='hidden'
-                    name='season'
-                    value={currentSeason.year}
-                  />
-                  <input
-                    type='hidden'
-                    name='preferences'
-                    value={JSON.stringify(
-                      Array.from(selectedSlots).map(draftSlotId => ({
-                        draftSlotId,
-                        available: true,
-                      })),
-                    )}
-                  />
+                {renderSlotGrid()}
+                <div className='my-4'>{renderSelectionStatus()}</div>
 
-                  <div
-                    style={{
-                      display: 'grid',
-                      gap: '1rem',
-                      marginBottom: '1rem',
-                    }}
-                  >
-                    {draftSlotsWithPreferences.map((slot: any) => (
-                      <div
-                        key={slot.id}
-                        style={{
-                          display: 'flex',
-                          alignItems: 'center',
-                          gap: '1rem',
-                        }}
-                      >
-                        <div
-                          style={{
-                            display: 'flex',
-                            alignItems: 'center',
-                            gap: '0.5rem',
-                          }}
-                        >
-                          <input
-                            type='checkbox'
-                            id={`slot-${slot.id}`}
-                            checked={selectedSlots.has(slot.id)}
-                            onChange={e => {
-                              setSelectedSlots(prev => {
-                                const newSelected = new Set(prev);
-                                if (e.target.checked) {
-                                  newSelected.add(slot.id);
-                                } else {
-                                  newSelected.delete(slot.id);
-                                }
-                                return newSelected;
-                              });
-                            }}
-                            style={{
-                              width: '18px',
-                              height: '18px',
-                              cursor: 'pointer',
-                            }}
-                          />
-                          <label
-                            htmlFor={`slot-${slot.id}`}
-                            style={{
-                              cursor: 'pointer',
-                              flex: 1,
-                              fontSize: '1rem',
-                            }}
-                          >
-                            {slot.draftDateTime.toLocaleString(undefined, {
-                              weekday: 'long',
-                              year: 'numeric',
-                              month: 'long',
-                              day: 'numeric',
-                              hour: 'numeric',
-                              minute: '2-digit',
-                              timeZoneName: 'short',
-                            })}
-                          </label>
-                        </div>
-                      </div>
-                    ))}
-                  </div>
-
-                  {!hasMinimumSelections && (
-                    <p
-                      style={{
-                        color: '#f44336',
-                        fontSize: '0.875rem',
-                        marginBottom: '1rem',
-                      }}
-                    >
-                      ⚠️ Please select at least 3 draft times you can make.
-                      Currently selected: {selectedSlots.size}
-                    </p>
-                  )}
-
-                  {selectedSlots.size > 0 && (
-                    <p
-                      style={{
-                        color: '#4caf50',
-                        fontSize: '0.875rem',
-                        marginBottom: '1rem',
-                      }}
-                    >
-                      ✓ {selectedSlots.size} draft time
-                      {selectedSlots.size === 1 ? '' : 's'} selected
-                    </p>
-                  )}
-
-                  <Button type='submit' disabled={!canSave}>
-                    Save Draft Preferences
-                  </Button>
-                </Form>
-              </div>
-            )}
+                <Button
+                  type='submit'
+                  disabled={!hasMinimumSelections || isSubmitting}
+                >
+                  Save Draft Preferences
+                </Button>
+              </Form>
+            </div>
+          )}
         </>
       ) : (
         <>
-          <p>
-            You have not yet registered for the {currentSeason.year} leagues.
-          </p>
-          {isRegistrationFull && (
-            <p>
-              The current season is fully subscribed. You can register below for
-              the wait list but a spot is not guaranteed.
-            </p>
-          )}
-          {currentSeason.isOpenForRegistration ? (
-            <Form method='post'>
-              <input type='hidden' name='actionType' value='register' />
-              <input type='hidden' name='year' value={currentSeason.year} />
-              <Button type='submit'>{buttonText}</Button>
-            </Form>
-          ) : (
+          {!currentSeason.isOpenForRegistration ? (
             <p>Registration is not currently open.</p>
+          ) : !hasDraftSlots ? (
+            <p>
+              Registration for the {currentSeason.year} leagues will open once
+              the draft times have been posted. Check back soon!
+            </p>
+          ) : (
+            <>
+              <p>
+                You have not yet registered for the {currentSeason.year}{' '}
+                leagues. To register, select all the draft times you can make —
+                at least {MINIMUM_DRAFT_TIMES}.
+              </p>
+              {isRegistrationFull && (
+                <p>
+                  The current season is fully subscribed. You can register below
+                  for the wait list but a spot is not guaranteed.
+                </p>
+              )}
+
+              <Form method='post'>
+                <input type='hidden' name='actionType' value='register' />
+                <input
+                  type='hidden'
+                  name='preferences'
+                  value={JSON.stringify(Array.from(selectedSlots))}
+                />
+
+                {renderSlotGrid()}
+                <div className='my-4'>{renderSelectionStatus()}</div>
+
+                <Button
+                  type='submit'
+                  disabled={!hasMinimumSelections || isSubmitting}
+                >
+                  {registerButtonText}
+                </Button>
+              </Form>
+            </>
           )}
         </>
       )}

--- a/app/routes/dashboard.tsx
+++ b/app/routes/dashboard.tsx
@@ -17,7 +17,7 @@ import {
 import type { Registration } from '~/models/registration.server';
 import {
   getRegistrationByUserAndYear,
-  getRegistrationsByYear,
+  getRegistrationCountByYear,
   registerWithDraftPreferences,
 } from '~/models/registration.server';
 import { getCurrentSeason } from '~/models/season.server';
@@ -43,9 +43,12 @@ function parseSelectedSlotIds(
   try {
     const parsed = JSON.parse(raw);
     if (!Array.isArray(parsed)) return null;
-    return parsed.filter(
+    const valid = parsed.filter(
       (id): id is string => typeof id === 'string' && validSlotIds.has(id),
     );
+    // Dedupe so a forged/replayed submission can't violate the
+    // (userId, draftSlotId) unique constraint.
+    return [...new Set(valid)];
   } catch {
     return null;
   }
@@ -103,13 +106,17 @@ export const action = async ({
       };
     }
 
-    await registerWithDraftPreferences(
-      user.id,
-      currentSeason.year,
-      currentSeason.id,
-      draftSlotIds,
-    );
-    return typedjson({ success: true });
+    try {
+      await registerWithDraftPreferences(
+        user.id,
+        currentSeason.year,
+        currentSeason.id,
+        draftSlotIds,
+      );
+      return typedjson({ success: true });
+    } catch {
+      return { formError: 'Failed to register. Please try again.' };
+    }
   }
 
   if (actionType === 'updateDraftPreferences') {
@@ -153,8 +160,9 @@ export const loader = async ({ request }: LoaderFunctionArgs) => {
     currentSeason.year,
   );
 
-  const registrations = await getRegistrationsByYear(currentSeason.year);
-  const registrationsCount = registrations.length;
+  const registrationsCount = await getRegistrationCountByYear(
+    currentSeason.year,
+  );
 
   // Draft slots for the current season, annotated with whether this user has
   // already selected each one. Loaded whether or not the user is registered so
@@ -229,7 +237,6 @@ export default function Dashboard() {
         >
           <input
             type='checkbox'
-            name='draftSlot'
             value={slot.id}
             checked={selectedSlots.has(slot.id)}
             onChange={e => toggleSlot(slot.id, e.target.checked)}

--- a/prisma/migrations/20260720212258_relate_draft_slots_to_season/migration.sql
+++ b/prisma/migrations/20260720212258_relate_draft_slots_to_season/migration.sql
@@ -1,0 +1,36 @@
+-- Add nullable seasonId columns first so existing rows can be backfilled
+ALTER TABLE "DraftSlot" ADD COLUMN "seasonId" TEXT;
+ALTER TABLE "DraftSlotPreference" ADD COLUMN "seasonId" TEXT;
+
+-- CopyExistingData: map DraftSlot.season (year) to the matching Season row
+UPDATE "DraftSlot" ds
+SET "seasonId" = s."id"
+FROM "Season" s
+WHERE s."year" = ds."season";
+
+-- CopyExistingData: inherit each preference's season from its draft slot
+UPDATE "DraftSlotPreference" dp
+SET "seasonId" = ds."seasonId"
+FROM "DraftSlot" ds
+WHERE ds."id" = dp."draftSlotId";
+
+-- Enforce NOT NULL. This fails loudly if any row could not be matched to a
+-- Season (e.g. a DraftSlot year with no Season row), rather than orphaning data.
+ALTER TABLE "DraftSlot" ALTER COLUMN "seasonId" SET NOT NULL;
+ALTER TABLE "DraftSlotPreference" ALTER COLUMN "seasonId" SET NOT NULL;
+
+-- Replace the (draftDateTime, season) unique index with (draftDateTime, seasonId)
+DROP INDEX "DraftSlot_draftDateTime_season_key";
+CREATE UNIQUE INDEX "DraftSlot_draftDateTime_seasonId_key" ON "DraftSlot"("draftDateTime", "seasonId");
+
+-- Season.year is now unique (fails loudly if duplicate-year rows exist)
+CREATE UNIQUE INDEX "Season_year_key" ON "Season"("year");
+
+-- Remove the old integer year columns and the now-unused ranking column
+ALTER TABLE "DraftSlot" DROP COLUMN "season";
+ALTER TABLE "DraftSlotPreference" DROP COLUMN "season";
+ALTER TABLE "DraftSlotPreference" DROP COLUMN "ranking";
+
+-- AddForeignKey
+ALTER TABLE "DraftSlot" ADD CONSTRAINT "DraftSlot_seasonId_fkey" FOREIGN KEY ("seasonId") REFERENCES "Season"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+ALTER TABLE "DraftSlotPreference" ADD CONSTRAINT "DraftSlotPreference_seasonId_fkey" FOREIGN KEY ("seasonId") REFERENCES "Season"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -266,11 +266,12 @@ model DraftSlot {
   updatedAt DateTime @updatedAt
 
   draftDateTime DateTime
-  season        Int
+  seasonId      String
+  season        Season   @relation(fields: [seasonId], references: [id], onDelete: Cascade)
 
   preferences DraftSlotPreference[]
 
-  @@unique([draftDateTime, season], name: "draftSlotDateTimeSeason")
+  @@unique([draftDateTime, seasonId], name: "draftSlotDateTimeSeason")
 }
 
 model DraftSlotPreference {
@@ -280,11 +281,11 @@ model DraftSlotPreference {
 
   userId      String
   draftSlotId String
-  season      Int
-  ranking     Int // 1 = most preferred, higher numbers = less preferred
+  seasonId    String
 
   user      User      @relation(fields: [userId], references: [id], onDelete: Cascade)
   draftSlot DraftSlot @relation(fields: [draftSlotId], references: [id], onDelete: Cascade)
+  season    Season    @relation(fields: [seasonId], references: [id], onDelete: Cascade)
 
   @@unique([userId, draftSlotId], name: "userDraftSlotPreference")
 }
@@ -667,14 +668,16 @@ model Season {
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt
 
-  year                  Int
+  year                  Int     @unique
   isCurrent             Boolean
   isOpenForRegistration Boolean
   isOpenForFSquared     Boolean @default(false)
   isOpenForDFSSurvivor  Boolean @default(false)
   registrationSize      Int     @default(60)
 
-  Weeks SeasonWeek[]
+  Weeks                SeasonWeek[]
+  draftSlots           DraftSlot[]
+  draftSlotPreferences DraftSlotPreference[]
 }
 
 model SeasonWeek {


### PR DESCRIPTION
## Summary
This PR refactors the draft slot preference system to use foreign key relationships to Season records instead of storing year integers, and consolidates the registration flow to combine registration and draft preference selection into a single atomic operation.

## Key Changes

### Database Schema & Migrations
- Added `seasonId` foreign key columns to `DraftSlot` and `DraftSlotPreference` tables
- Removed `season` (year integer) columns from both tables
- Removed `ranking` column from `DraftSlotPreference` (preferences are now unranked availability selections)
- Created migration to backfill `seasonId` values from existing year data and enforce referential integrity
- Added unique constraint on `Season.year` to prevent duplicate season years

### Registration Flow
- Combined registration and draft preference selection into a single atomic operation via new `registerWithDraftPreferences()` function
- Users now select at least 3 draft times during registration, not as a separate step
- Registration form displays draft time slots and validates minimum selection before submission
- Removed separate "register then set preferences" flow

### Dashboard Component
- Refactored to show draft slots to both registered and unregistered users
- Unregistered users select draft times as part of registration
- Registered users can update their draft preferences separately
- Added visual feedback for selection status (green checkmark when minimum met, red warning otherwise)
- Improved form validation with `parseSelectedSlotIds()` helper to sanitize and deduplicate user input
- Added loading state tracking with `useNavigation()` hook

### Data Models
- Updated `getDraftSlotsWithUserPreferences()` to use `seasonId` and return `isSelected` boolean instead of `userRanking`
- Updated `getUserDraftSlotPreferences()` to accept `seasonId` instead of year integer
- Updated `upsertUserDraftSlotPreferences()` to accept array of slot IDs instead of ranked preferences
- Added `getRegistrationCountByYear()` helper function
- Updated all draft slot queries to join with Season table for year information

### Admin Routes
- Updated draft slot creation/editing to use `seasonId` instead of `season` year
- Updated sorting/announcement logic to reference season year through relationship
- Simplified preference handling in sorting algorithm (removed ranking logic)

## Notable Implementation Details
- Draft preference updates use Prisma transactions to ensure atomicity
- Form submission includes hidden input with JSON-stringified slot IDs for validation on server
- Minimum draft time selection constant (`MINIMUM_DRAFT_TIMES = 3`) centralized for consistency
- Registration is blocked if no draft slots exist for the season (prevents registration before times are posted)

https://claude.ai/code/session_01Xx4rW2iFPG832esrijChzJ